### PR TITLE
Improve how username is derived for templates

### DIFF
--- a/lib/automations/todos/utils/get-details.js
+++ b/lib/automations/todos/utils/get-details.js
@@ -39,7 +39,7 @@ module.exports = ( { context, chunk, config, line, lineCount } ) => {
 		sha = context.payload.head_commit.id;
 	} else {
 		// Get it from the head ref in this PR
-		username = context.payload.pull_request.head.user.login;
+		username = context.payload.pull_request.user.login;
 		sha = context.payload.pull_request.head.sha;
 	}
 


### PR DESCRIPTION
It looks like the current implementation for deriving `username` will end up actually pulling the "organization" user login value vs the author of a commit from the payload. The work in this pull ensures wherever we use `cc @` values, that we're not pinging the whole organization.