### PR TITLE
Remove unnecessary redundant mapping

### DIFF
--- a/lib/automations.js
+++ b/lib/automations.js
@@ -1,7 +1,3 @@
-const todos = require( './automations/todos' );
-
-const moduleNames = [ todos ];
-
 /**
  * @typedef {import('./typedefs').AutomationTask} AutomationTask
  */
@@ -9,6 +5,4 @@ const moduleNames = [ todos ];
 /**
  * @type {AutomationTask[]}
  */
-const automations = moduleNames.map( ( module ) => module );
-
-module.exports = automations;
+module.exports = [ require( './automations/todos' ) ];


### PR DESCRIPTION
The `lib/automations.js` file has redundant mapping for the registered todos.  This pull simplifies things.