### PR TITLE
Switch logic to get next minor release milestone by title

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -130,8 +130,8 @@ module.exports = async ( context, octokit ) => {
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		//debug( `assign-milestone: Review state is not approved--bailing.` );
-		//return;
+		debug( `assign-milestone: Review state is not approved--bailing.` );
+		return;
 	}
 
 	// Check current milestone

--- a/lib/automations/assign-milestone/README.md
+++ b/lib/automations/assign-milestone/README.md
@@ -3,6 +3,8 @@
 When a pull request is approved and is not already assigned a milestone, this automation will assign the next milestone to it
 automatically.
 
+The next milestone will be the next minor version, calculated from the current version in package.json. So for example, if the current version is 2.5.2, the milestone will be 2.6 (if it exists).
+
 ## Usage
 
 To implement this action, include it in your workflow configuration file:

--- a/lib/automations/assign-milestone/get-version.js
+++ b/lib/automations/assign-milestone/get-version.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+const core = require( '@actions/core' );
+
+/**
+ * @typedef {import('../../../typedefs').GitHubContext} GitHubContext
+ * @typedef {import('../../../typedefs').GitHub} GitHub
+ */
+
+/**
+ * Return the version found in package.json.
+ *
+ * @param {GitHubContext} context
+ * @param {GitHub} octokit
+ * @return {string} Version
+ */
+module.exports = async ( context, octokit ) => {
+	try {
+		core.debug( 'Fetching `package.json` contents' );
+
+		const response = await octokit.repos.getContent( {
+			...context.repo,
+			path: 'package.json',
+		} );
+
+		if (
+			response.data &&
+			response.data.content &&
+			response.data.encoding
+		) {
+			const buffer = Buffer.from(
+				response.data.content,
+				response.data.encoding
+			);
+			const { version } = JSON.parse( buffer.toString( 'utf-8' ) );
+
+			core.debug( `Found version: ${ version }` );
+
+			return version;
+		}
+
+		throw new Error( 'No content found' );
+	} catch ( error ) {
+		core.debug(
+			`Could not find version in package.json. Failed with error: ${ error }`
+		);
+	}
+
+	return false;
+};

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -23,8 +23,8 @@ module.exports = async ( context, octokit ) => {
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		//debug( `assign-milestone: Review state is not approved--bailing.` );
-		//return;
+		debug( `assign-milestone: Review state is not approved--bailing.` );
+		return;
 	}
 
 	// Check current milestone

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -3,6 +3,7 @@
  */
 const debug = require( '../../debug' );
 const { getMilestoneByTitle } = require( '../../utils' );
+const getVersion = require( './get-version' );
 
 /**
  * @typedef {import('../../typedefs').GitHubContext} GitHubContext
@@ -22,8 +23,8 @@ module.exports = async ( context, octokit ) => {
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		debug( `assign-milestone: Review state is not approved--bailing.` );
-		return;
+		//debug( `assign-milestone: Review state is not approved--bailing.` );
+		//return;
 	}
 
 	// Check current milestone
@@ -34,19 +35,14 @@ module.exports = async ( context, octokit ) => {
 		return;
 	}
 
-	// Get version.
-	debug( 'assign-milestone: Fetching `package.json` contents' );
+	const version = await getVersion( context, octokit );
 
-	const {
-		data: { content, encoding },
-	} = await octokit.repos.getContents( {
-		...context.repo,
-		path: 'package.json',
-	} );
-
-	const { version } = JSON.parse(
-		Buffer.from( content, encoding ).toString()
-	);
+	if ( ! version ) {
+		debug(
+			`assign-milestone: Unable to find current version number--bailing.`
+		);
+		return;
+	}
 
 	let [ major, minor ] = version.split( '.' ).map( Number );
 

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 const debug = require( '../../debug' );
+const { getMilestoneByTitle } = require( '../../utils' );
 
 /**
  * @typedef {import('../../typedefs').GitHubContext} GitHubContext
@@ -16,53 +17,81 @@ module.exports = async ( context, octokit ) => {
 	const pullNumber = context.payload.pull_request.number;
 	const reviewState = context.payload.review.state;
 
-	debug(
-		`pullRequestReviewHandler: Pull Request number is [${ pullNumber }].`
-	);
-	debug( `pullRequestReviewHandler: Review state is [${ reviewState }].` );
+	debug( `assign-milestone: Pull Request number is [${ pullNumber }].` );
+	debug( `assign-milestone: Review state is [${ reviewState }].` );
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		debug(
-			`pullRequestReviewHandler: Review state is not approved--bailing.`
-		);
+		debug( `assign-milestone: Review state is not approved--bailing.` );
 		return;
 	}
 
 	// Check current milestone
 	if ( context.payload.pull_request.milestone !== null ) {
 		debug(
-			`pullRequestReviewHandler: Pull request already has a milestone--bailing.`
+			`assign-milestone: Pull request already has a milestone--bailing.`
 		);
 		return;
 	}
 
-	// Get next milestone
-	const milestones = await octokit.issues.listMilestones( {
+	// Get version.
+	debug( 'assign-milestone: Fetching `package.json` contents' );
+
+	const {
+		data: { content, encoding },
+	} = await octokit.repos.getContents( {
 		...context.repo,
-		sort: 'due_on',
-		direction: 'asc',
+		path: 'package.json',
 	} );
 
-	if ( ! milestones.data || ! milestones.data[ 0 ] ) {
+	const { version } = JSON.parse(
+		Buffer.from( content, encoding ).toString()
+	);
+
+	let [ major, minor ] = version.split( '.' ).map( Number );
+
+	debug(
+		`assign-milestone: Current plugin version is ${ major }.${ minor }`
+	);
+
+	// Calculate next milestone
+	if ( minor === 9 ) {
+		major += 1;
+		minor = 0;
+	} else {
+		minor += 1;
+	}
+
+	const nextMilestone = `${ major }.${ minor }`;
+
+	// Get next milestone
+	const milestone = await getMilestoneByTitle(
+		context,
+		octokit,
+		nextMilestone
+	);
+
+	if ( ! milestone ) {
 		debug(
-			`pullRequestReviewHandler: There are no milestones available to assign to this PR.`
+			`assign-milestone: Could not rediscover milestone by title: ${ nextMilestone }`
 		);
 		return;
 	}
 
-	const milestoneNumber = milestones.data[ 0 ].number;
-
 	// Assign milestone
+	debug(
+		`assign-milestone: Adding issue #${ pullNumber } to milestone #${ milestone.number }`
+	);
+
 	const milestoneAssigned = await octokit.issues.update( {
 		...context.repo,
 		issue_number: pullNumber,
-		milestone: milestoneNumber,
+		milestone: milestone.number,
 	} );
 
 	if ( ! milestoneAssigned ) {
 		debug(
-			`pullRequestReviewHandler: Could not assign milestone [${ milestoneNumber }] to pull request [${ pullNumber }].`
+			`assign-milestone: Could not assign milestone [${ milestone.number }] to pull request [${ pullNumber }].`
 		);
 	}
 };

--- a/lib/automations/assign-milestone/test/__snapshots__/pull-request-review-handler.js.snap
+++ b/lib/automations/assign-milestone/test/__snapshots__/pull-request-review-handler.js.snap
@@ -4,7 +4,7 @@ exports[`pull-request-review-handler assigns milestones to pull requests assigns
 Array [
   Object {
     "issue_number": 40,
-    "milestone": 3,
+    "milestone": 1235,
     "owner": "nerrad",
     "repo": "tests",
   },

--- a/lib/automations/assign-milestone/test/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/test/pull-request-review-handler.js
@@ -25,7 +25,10 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 	} );
 	it( 'assigns a milestone to an approved pull request', async () => {
 		await app( context, octokit );
-		expect( octokit.issues.listMilestones ).toHaveBeenCalled();
+		expect( octokit.repos.getContents ).toHaveBeenCalled();
+		expect(
+			octokit.issues.listMilestones.endpoint.merge
+		).toHaveBeenCalled();
 		expect( octokit.issues.update ).toHaveBeenCalled();
 		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 	} );

--- a/lib/automations/assign-milestone/test/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/test/pull-request-review-handler.js
@@ -24,8 +24,20 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 		expect( octokit.issues.update ).not.toHaveBeenCalled();
 	} );
 	it( 'assigns a milestone to an approved pull request', async () => {
+		octokit.repos.getContent.mockReturnValueOnce(
+			Promise.resolve( {
+				data: {
+					content: Buffer.from(
+						JSON.stringify( {
+							version: '3.0.0',
+						} )
+					).toString( 'base64' ),
+					encoding: 'base64',
+				},
+			} )
+		);
 		await app( context, octokit );
-		expect( octokit.repos.getContents ).toHaveBeenCalled();
+		expect( octokit.repos.getContent ).toHaveBeenCalled();
 		expect(
 			octokit.issues.listMilestones.endpoint.merge
 		).toHaveBeenCalled();

--- a/tests/fixtures/payloads/milestone-list.json
+++ b/tests/fixtures/payloads/milestone-list.json
@@ -6,7 +6,7 @@
 		"id": 6838654,
 		"node_id": "MDk6TWlsZXN0b25lNjgzODY1NA==",
 		"number": 3,
-		"title": "1.3.0",
+		"title": "3.0.0",
 		"description": "Test future milestone",
 		"creator": {
 			"login": "mikejolley",
@@ -43,7 +43,7 @@
 		"id": 6838656,
 		"node_id": "MDk6TWlsZXN0b25lNjgzODY1Ng==",
 		"number": 4,
-		"title": "1.4.0",
+		"title": "3.1.0",
 		"description": "Test future milestone.",
 		"creator": {
 			"login": "mikejolley",

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -102,6 +102,20 @@ exports.gimmeOctokit = () => {
 			getContent: jest
 				.fn( () => Promise.resolve( { content: '' } ) )
 				.mockName( 'repos.getContent' ),
+			getContents: jest
+				.fn( () =>
+					Promise.resolve( {
+						data: {
+							content: Buffer.from(
+								JSON.stringify( {
+									version: '3.0.0',
+								} )
+							).toString( 'base64' ),
+							encoding: 'base64',
+						},
+					} )
+				)
+				.mockName( 'repos.getContents' ),
 			getBranch: jest.fn().mockName( 'repos.getBranch' ),
 		},
 		pulls: {
@@ -116,7 +130,12 @@ exports.gimmeOctokit = () => {
 					switch ( options.type ) {
 						case 'list.milestones':
 							return mockedAsyncIterator( [
-								{ data: [ { title: '3.0.0', number: 1234 } ] },
+								{
+									data: [
+										{ title: '3.0.0', number: 1234 },
+										{ title: '3.1.0', number: 1235 },
+									],
+								},
 							] )();
 						case 'list.issues':
 							return mockedAsyncIterator( [

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -100,22 +100,8 @@ exports.gimmeOctokit = () => {
 				.fn( () => loadDiff( 'basic' ) )
 				.mockName( 'repos.getCommit' ),
 			getContent: jest
-				.fn( () => Promise.resolve( { content: '' } ) )
+				.fn( () => Promise.resolve( { data: { content: '' } } ) )
 				.mockName( 'repos.getContent' ),
-			getContents: jest
-				.fn( () =>
-					Promise.resolve( {
-						data: {
-							content: Buffer.from(
-								JSON.stringify( {
-									version: '3.0.0',
-								} )
-							).toString( 'base64' ),
-							encoding: 'base64',
-						},
-					} )
-				)
-				.mockName( 'repos.getContents' ),
 			getBranch: jest.fn().mockName( 'repos.getBranch' ),
 		},
 		pulls: {


### PR DESCRIPTION
Updates the assign-milestone logic to select the next milestone based on the version in package.json + 1. If this works, when approved this PR will be assigned 1.4.0 and none of the red herring milestones I just created.

Tests are updated. Based on https://github.com/WordPress/gutenberg/tree/trunk/packages/project-management-automation/lib/tasks/add-milestone.

Will deploy a new release once working :)