### PR TITLE
Add bump strategy option to assign-milestone action

### DIFF
--- a/.github/workflows/approved-automation.yml
+++ b/.github/workflows/approved-automation.yml
@@ -9,5 +9,4 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
-                  config:
-                      bump_strategy: 'ignore'
+                  milestone_bump_strategy: none

--- a/.github/workflows/approved-automation.yml
+++ b/.github/workflows/approved-automation.yml
@@ -9,5 +9,5 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
-                  inputs:
+                  config:
                       bump_strategy: 'ignore'

--- a/.github/workflows/approved-automation.yml
+++ b/.github/workflows/approved-automation.yml
@@ -9,3 +9,5 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
+                  inputs:
+                      bump_strategy: ignore

--- a/.github/workflows/approved-automation.yml
+++ b/.github/workflows/approved-automation.yml
@@ -10,4 +10,4 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
                   inputs:
-                      bump_strategy: ignore
+                      bump_strategy: 'ignore'

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,19 @@
 name: Project management automations
 author: Darren Ethier
 description: >
-  Various automations to assist with project management of a repository.
+    Various automations to assist with project management of a repository.
 inputs:
-  github_token:
-    description: Secret GitHub API token to use for making API requests.
-    required: true
-  automations:
-    description: A list of specific automations you want to run if you don't want to use them all in a given workflow. If not included, all of the current automations will run.
-    required: false
-    default: ''
+    github_token:
+        description: Secret GitHub API token to use for making API requests.
+        required: true
+    automations:
+        description: A list of specific automations you want to run if you don't want to use them all in a given workflow. If not included, all of the current automations will run.
+        required: false
+        default: ''
+    config:
+        description: A list of config parameters to pass to the automation (if supported).
+        required: false
+        default: ''
 runs:
-  using: 'node12'
-  main: 'dist/index.js'
+    using: 'node12'
+    main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,19 @@ inputs:
         description: Secret GitHub API token to use for making API requests.
         required: true
     automations:
-        description: A list of specific automations you want to run if you don't want to use them all in a given workflow. If not included, all of the current automations will run.
+        description: |
+            A list of specific automations you want to run if you don't want to use them all in a given workflow. If not included, all of the current automations will run.
         required: false
         default: ''
-    config:
-        description: A list of config parameters to pass to the automation (if supported).
+    milestone_bump_strategy:
+        description: |
+            For the assign-milestone workflow, this controls which milestone is selected based on the version in package.json:
+                'none'  - Assign to the current major.minor version.
+                'patch' - Assign to the next patch version.
+                'minor' - Assign to the next minor version.
+                'major' - Assign to the next major version.
         required: false
-        default: ''
+        default: minor
 runs:
     using: 'node12'
     main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -53,7 +53,7 @@ const getInput = ( input ) => {
 		throw new Error( `Missing required input ${ input.input }` );
 	}
 
-	if ( value && input.allowed && ! value.includes( input.allowed ) ) {
+	if ( value && input.allowed && ! input.allowed.includes( value ) ) {
 		throw new Error(
 			`Input ${
 				input.input

--- a/dist/index.js
+++ b/dist/index.js
@@ -68,11 +68,9 @@ const getInput = ( input ) => {
 
 module.exports = async () => {
 	try {
-		const config = {
+		return {
 			bumpStrategy: getInput( inputs.bumpStrategy ),
 		};
-
-		return config;
 	} catch ( error ) {
 		setFailed( `assign-milestone: ${ error }` );
 	}
@@ -202,6 +200,9 @@ module.exports = async ( context, octokit, config ) => {
 	const pullNumber = context.payload.pull_request.number;
 	const reviewState = context.payload.review.state;
 
+	debug(
+		`assign-milestone: Received config [${ JSON.stringify( config ) }].`
+	);
 	debug( `assign-milestone: Pull Request number is [${ pullNumber }].` );
 	debug( `assign-milestone: Review state is [${ reviewState }].` );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -208,8 +208,8 @@ module.exports = async ( context, octokit, config ) => {
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		//debug( `assign-milestone: Review state is not approved--bailing.` );
-		//return;
+		debug( `assign-milestone: Review state is not approved--bailing.` );
+		return;
 	}
 
 	// Check current milestone

--- a/dist/index.js
+++ b/dist/index.js
@@ -141,7 +141,7 @@ module.exports = async ( context, octokit ) => {
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 const runner = __webpack_require__( 2433 );
-const { getConfig } = __webpack_require__( 5783 );
+const getConfig = __webpack_require__( 5783 );
 
 module.exports = {
 	name: 'assign-milestone',

--- a/lib/automations/assign-milestone/README.md
+++ b/lib/automations/assign-milestone/README.md
@@ -27,7 +27,7 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   # This can be a comma delimited list of automations to run, in this case we're just executing assign-milestone
                   automations: assign-milestone
-                  inputs:
+                  config:
                       # one of ignore, minor, or major
                       bump_strategy: 'ignore'
 ```

--- a/lib/automations/assign-milestone/README.md
+++ b/lib/automations/assign-milestone/README.md
@@ -3,9 +3,12 @@
 When a pull request is approved and is not already assigned a milestone, this automation will assign the next milestone to it
 automatically.
 
-The next milestone will be calculated from the current version in package.json. So for example, if the current version is 2.5.2, the milestone will be 2.6 (if it exists) by default.
+The next milestone will be calculated from the current version in package.json. By default this will be the next minor version, but setting `milestone_bump_strategy` can change this:
 
-Setting a `bump_strategy` to `ignore` will use the version found in package.json. `major` will increase the major version.
+-   `none` - Assign to the current major.minor version.
+-   `patch` - Assign to the next patch version.
+-   `minor` - Assign to the next minor version.
+-   `major` - Assign to the next major version.
 
 ## Usage
 
@@ -27,9 +30,7 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   # This can be a comma delimited list of automations to run, in this case we're just executing assign-milestone
                   automations: assign-milestone
-                  config:
-                      # one of ignore, minor, or major
-                      bump_strategy: 'ignore'
+                  milestone_bump_strategy: none
 ```
 
 ## API
@@ -38,6 +39,7 @@ jobs:
 
 -   `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
 -   `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
+-   `milestone_bump_strategy`: Optional. For the assign-milestone workflow, this controls which milestone is selected.
 
 ### Outputs
 

--- a/lib/automations/assign-milestone/README.md
+++ b/lib/automations/assign-milestone/README.md
@@ -29,7 +29,7 @@ jobs:
                   automations: assign-milestone
                   inputs:
                       # one of ignore, minor, or major
-                      bump_strategy: ignore
+                      bump_strategy: 'ignore'
 ```
 
 ## API

--- a/lib/automations/assign-milestone/README.md
+++ b/lib/automations/assign-milestone/README.md
@@ -3,7 +3,9 @@
 When a pull request is approved and is not already assigned a milestone, this automation will assign the next milestone to it
 automatically.
 
-The next milestone will be the next minor version, calculated from the current version in package.json. So for example, if the current version is 2.5.2, the milestone will be 2.6 (if it exists).
+The next milestone will be calculated from the current version in package.json. So for example, if the current version is 2.5.2, the milestone will be 2.6 (if it exists) by default.
+
+Setting a `bump_strategy` to `ignore` will use the version found in package.json. `major` will increase the major version.
 
 ## Usage
 
@@ -25,6 +27,9 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   # This can be a comma delimited list of automations to run, in this case we're just executing assign-milestone
                   automations: assign-milestone
+                  inputs:
+                      # one of ignore, minor, or major
+                      bump_strategy: ignore
 ```
 
 ## API

--- a/lib/automations/assign-milestone/get-config.js
+++ b/lib/automations/assign-milestone/get-config.js
@@ -1,25 +1,45 @@
 /**
  * External dependencies
  */
-const { setFailed, getInput, debug: coreDebug } = require( '@actions/core' );
+const { setFailed, getInput: coreGetInput } = require( '@actions/core' );
 
-const allowedBumpStrategy = [ 'minor', 'ignore', 'major' ];
+const inputs = {
+	bumpStrategy: {
+		input: 'milestone_bump_strategy',
+		allowed: [ 'none', 'patch', 'minor', 'major' ],
+		default: 'minor',
+		required: false,
+	},
+};
 
-module.exports = async () => {
-	const repoConfig = getInput( 'config' ) || {};
-	const config = {
-		bumpStrategy: repoConfig.bump_strategy || 'minor',
-	};
+const getInput = ( input ) => {
+	const value = coreGetInput( input.input ) || input.default;
 
-	coreDebug( 'retrieved config: ' + JSON.stringify( config ) );
+	if ( input.required && ! value ) {
+		throw new Error( `Missing required input ${ input.input }` );
+	}
 
-	if ( ! config.bumpStrategy.includes( allowedBumpStrategy ) ) {
-		setFailed(
-			`assign-milestone: Invalid bumpStrategy provided. Allowed values: ${ JSON.stringify(
-				allowedBumpStrategy
+	if ( value && input.allowed && ! value.includes( input.allowed ) ) {
+		throw new Error(
+			`Input ${
+				input.input
+			} provided with value "${ value }" must be one of ${ JSON.stringify(
+				input.allowed
 			) }`
 		);
 	}
 
-	return config;
+	return value;
+};
+
+module.exports = async () => {
+	try {
+		const config = {
+			bumpStrategy: getInput( inputs.bumpStrategy ),
+		};
+
+		return config;
+	} catch ( error ) {
+		setFailed( `assign-milestone: ${ error }` );
+	}
 };

--- a/lib/automations/assign-milestone/get-config.js
+++ b/lib/automations/assign-milestone/get-config.js
@@ -19,7 +19,7 @@ const getInput = ( input ) => {
 		throw new Error( `Missing required input ${ input.input }` );
 	}
 
-	if ( value && input.allowed && ! value.includes( input.allowed ) ) {
+	if ( value && input.allowed && ! input.allowed.includes( value ) ) {
 		throw new Error(
 			`Input ${
 				input.input

--- a/lib/automations/assign-milestone/get-config.js
+++ b/lib/automations/assign-milestone/get-config.js
@@ -34,11 +34,9 @@ const getInput = ( input ) => {
 
 module.exports = async () => {
 	try {
-		const config = {
+		return {
 			bumpStrategy: getInput( inputs.bumpStrategy ),
 		};
-
-		return config;
 	} catch ( error ) {
 		setFailed( `assign-milestone: ${ error }` );
 	}

--- a/lib/automations/assign-milestone/get-config.js
+++ b/lib/automations/assign-milestone/get-config.js
@@ -6,8 +6,9 @@ const { setFailed, getInput, debug: coreDebug } = require( '@actions/core' );
 const allowedBumpStrategy = [ 'minor', 'ignore', 'major' ];
 
 module.exports = async () => {
+	const repoConfig = getInput( 'config' ) || {};
 	const config = {
-		bumpStrategy: getInput( 'bump_strategy' ) || 'minor',
+		bumpStrategy: repoConfig.bump_strategy || 'minor',
 	};
 
 	coreDebug( 'retrieved config: ' + JSON.stringify( config ) );

--- a/lib/automations/assign-milestone/get-config.js
+++ b/lib/automations/assign-milestone/get-config.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+const { setFailed, getInput, debug: coreDebug } = require( '@actions/core' );
+
+const allowedBumpStrategy = [ 'minor', 'ignore', 'major' ];
+
+module.exports = async () => {
+	const config = {
+		bumpStrategy: getInput( 'bump_strategy' ) || 'minor',
+	};
+
+	coreDebug( 'retrieved config: ' + JSON.stringify( config ) );
+
+	if ( ! config.bumpStrategy.includes( allowedBumpStrategy ) ) {
+		setFailed(
+			`assign-milestone: Invalid bumpStrategy provided. Allowed values: ${ JSON.stringify(
+				allowedBumpStrategy
+			) }`
+		);
+	}
+
+	return config;
+};

--- a/lib/automations/assign-milestone/index.js
+++ b/lib/automations/assign-milestone/index.js
@@ -1,5 +1,5 @@
 const runner = require( './runner' );
-const { getConfig } = require( './get-config' );
+const getConfig = require( './get-config' );
 
 module.exports = {
 	name: 'assign-milestone',

--- a/lib/automations/assign-milestone/index.js
+++ b/lib/automations/assign-milestone/index.js
@@ -1,8 +1,10 @@
 const runner = require( './runner' );
+const { getConfig } = require( './get-config' );
 
 module.exports = {
 	name: 'assign-milestone',
 	events: [ 'pull_request_review' ],
 	actions: [ 'submitted', 'edited' ],
 	runner,
+	getConfig,
 };

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -13,8 +13,9 @@ const getVersion = require( './get-version' );
 /**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
+ * @param {Object} config
  */
-module.exports = async ( context, octokit ) => {
+module.exports = async ( context, octokit, config ) => {
 	const pullNumber = context.payload.pull_request.number;
 	const reviewState = context.payload.review.state;
 
@@ -23,8 +24,8 @@ module.exports = async ( context, octokit ) => {
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		debug( `assign-milestone: Review state is not approved--bailing.` );
-		return;
+		//debug( `assign-milestone: Review state is not approved--bailing.` );
+		//return;
 	}
 
 	// Check current milestone
@@ -50,12 +51,17 @@ module.exports = async ( context, octokit ) => {
 		`assign-milestone: Current plugin version is ${ major }.${ minor }`
 	);
 
+	console.log( config );
 	// Calculate next milestone
-	if ( minor === 9 ) {
+	if ( config.bumpStrategy === 'minor' ) {
+		if ( minor === 9 ) {
+			major += 1;
+			minor = 0;
+		} else {
+			minor += 1;
+		}
+	} else if ( config.bumpStrategy === 'major' ) {
 		major += 1;
-		minor = 0;
-	} else {
-		minor += 1;
 	}
 
 	const nextMilestone = `${ major }.${ minor }`;

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -10,6 +10,28 @@ const getVersion = require( './get-version' );
  * @typedef {import('../../typedefs').GitHub} GitHub
  */
 
+const getTargetMilestone = ( major, minor, patch, bumpStrategy = 'none' ) => {
+	if ( bumpStrategy === 'patch' ) {
+		patch += 1;
+		return `${ major }.${ minor }.${ patch }`;
+	}
+
+	if ( bumpStrategy === 'minor' ) {
+		if ( minor === 9 ) {
+			major += 1;
+			minor = 0;
+		} else {
+			minor += 1;
+		}
+	}
+
+	if ( bumpStrategy === 'major' ) {
+		major += 1;
+	}
+
+	return `${ major }.${ minor }`;
+};
+
 /**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
@@ -45,26 +67,21 @@ module.exports = async ( context, octokit, config ) => {
 		return;
 	}
 
-	let [ major, minor ] = version.split( '.' ).map( Number );
+	const [ major = 0, minor = 0, patch = 0 ] = version
+		.split( '.' )
+		.map( Number );
 
 	debug(
-		`assign-milestone: Current plugin version is ${ major }.${ minor }`
+		`assign-milestone: Current plugin version is ${ major }.${ minor }.${ patch }`
 	);
 
-	console.log( config );
 	// Calculate next milestone
-	if ( config.bumpStrategy === 'minor' ) {
-		if ( minor === 9 ) {
-			major += 1;
-			minor = 0;
-		} else {
-			minor += 1;
-		}
-	} else if ( config.bumpStrategy === 'major' ) {
-		major += 1;
-	}
-
-	const nextMilestone = `${ major }.${ minor }`;
+	const nextMilestone = getTargetMilestone(
+		major,
+		minor,
+		patch,
+		config.bumpStrategy
+	);
 
 	// Get next milestone
 	const milestone = await getMilestoneByTitle(

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -49,8 +49,8 @@ module.exports = async ( context, octokit, config ) => {
 
 	// Check state
 	if ( reviewState !== 'approved' ) {
-		//debug( `assign-milestone: Review state is not approved--bailing.` );
-		//return;
+		debug( `assign-milestone: Review state is not approved--bailing.` );
+		return;
 	}
 
 	// Check current milestone

--- a/lib/automations/assign-milestone/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/pull-request-review-handler.js
@@ -41,6 +41,9 @@ module.exports = async ( context, octokit, config ) => {
 	const pullNumber = context.payload.pull_request.number;
 	const reviewState = context.payload.review.state;
 
+	debug(
+		`assign-milestone: Received config [${ JSON.stringify( config ) }].`
+	);
 	debug( `assign-milestone: Pull Request number is [${ pullNumber }].` );
 	debug( `assign-milestone: Review state is [${ reviewState }].` );
 

--- a/lib/automations/assign-milestone/runner.js
+++ b/lib/automations/assign-milestone/runner.js
@@ -44,14 +44,15 @@ const getRunnerTask = ( eventName, action ) => {
  *
  * @param {GitHubContext} context Context for the job run (github).
  * @param {GitHub}        octokit GitHub api helper.
+ * @param {Object}        config  Config object.
  *
  * @return {AutomationTaskRunner} task runner.
  */
-const runner = async ( context, octokit ) => {
+const runner = async ( context, octokit, config ) => {
 	const task = getRunnerTask( context.eventName, context.payload.action );
 	if ( typeof task === 'function' ) {
 		debug( `assignMilestoneRunner: Executing the ${ task.name } task.` );
-		await task( context, octokit );
+		await task( context, octokit, config );
 	} else {
 		setFailed(
 			`assignMilestoneRunner: There is no configured task for the event = '${ context.eventName }' and the payload action = '${ context.payload.action }'`

--- a/lib/automations/assign-milestone/test/__snapshots__/pull-request-review-handler.js.snap
+++ b/lib/automations/assign-milestone/test/__snapshots__/pull-request-review-handler.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`pull-request-review-handler assigns milestones to pull requests assigns a milestone to an approved pull request 1`] = `
+exports[`pull-request-review-handler assigns milestone assigns a milestone to an approved pull request 1`] = `
 Array [
   Object {
     "issue_number": 40,
@@ -11,18 +11,7 @@ Array [
 ]
 `;
 
-exports[`pull-request-review-handler assigns milestones to pull requests ignore bumpStrategy 1`] = `
-Array [
-  Object {
-    "issue_number": 40,
-    "milestone": 300,
-    "owner": "nerrad",
-    "repo": "tests",
-  },
-]
-`;
-
-exports[`pull-request-review-handler assigns milestones to pull requests major bumpStrategy 1`] = `
+exports[`pull-request-review-handler assigns milestone based on bumpStrategy major 1`] = `
 Array [
   Object {
     "issue_number": 40,
@@ -33,11 +22,33 @@ Array [
 ]
 `;
 
-exports[`pull-request-review-handler assigns milestones to pull requests minor bumpStrategy 1`] = `
+exports[`pull-request-review-handler assigns milestone based on bumpStrategy minor 1`] = `
 Array [
   Object {
     "issue_number": 40,
     "milestone": 310,
+    "owner": "nerrad",
+    "repo": "tests",
+  },
+]
+`;
+
+exports[`pull-request-review-handler assigns milestone based on bumpStrategy none 1`] = `
+Array [
+  Object {
+    "issue_number": 40,
+    "milestone": 300,
+    "owner": "nerrad",
+    "repo": "tests",
+  },
+]
+`;
+
+exports[`pull-request-review-handler assigns milestone based on bumpStrategy patch 1`] = `
+Array [
+  Object {
+    "issue_number": 40,
+    "milestone": 301,
     "owner": "nerrad",
     "repo": "tests",
   },

--- a/lib/automations/assign-milestone/test/__snapshots__/pull-request-review-handler.js.snap
+++ b/lib/automations/assign-milestone/test/__snapshots__/pull-request-review-handler.js.snap
@@ -4,7 +4,40 @@ exports[`pull-request-review-handler assigns milestones to pull requests assigns
 Array [
   Object {
     "issue_number": 40,
-    "milestone": 1235,
+    "milestone": 310,
+    "owner": "nerrad",
+    "repo": "tests",
+  },
+]
+`;
+
+exports[`pull-request-review-handler assigns milestones to pull requests ignore bumpStrategy 1`] = `
+Array [
+  Object {
+    "issue_number": 40,
+    "milestone": 300,
+    "owner": "nerrad",
+    "repo": "tests",
+  },
+]
+`;
+
+exports[`pull-request-review-handler assigns milestones to pull requests major bumpStrategy 1`] = `
+Array [
+  Object {
+    "issue_number": 40,
+    "milestone": 400,
+    "owner": "nerrad",
+    "repo": "tests",
+  },
+]
+`;
+
+exports[`pull-request-review-handler assigns milestones to pull requests minor bumpStrategy 1`] = `
+Array [
+  Object {
+    "issue_number": 40,
+    "milestone": 310,
     "owner": "nerrad",
     "repo": "tests",
   },

--- a/lib/automations/assign-milestone/test/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/test/pull-request-review-handler.js
@@ -1,6 +1,6 @@
 const { gimmeOctokit, gimmeContext, gimmeApp } = require( '@testHelpers' );
 
-describe( 'pull-request-review-handler assigns milestones to pull requests', () => {
+describe( 'pull-request-review-handler assigns milestone', () => {
 	let octokit, context, app;
 	beforeEach( () => {
 		octokit = gimmeOctokit();
@@ -50,7 +50,7 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 		expect( octokit.issues.update ).toHaveBeenCalled();
 		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 	} );
-	describe( 'pull-request-review-handler assigns correct milestone for bumpStrategy', () => {
+	describe( 'based on bumpStrategy', () => {
 		beforeEach( () => {
 			octokit.repos.getContent.mockReturnValueOnce(
 				Promise.resolve( {
@@ -65,28 +65,28 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 				} )
 			);
 		} );
-		it( 'none bumpStrategy', async () => {
+		it( 'none', async () => {
 			await app( context, octokit, {
 				bumpStrategy: 'none',
 			} );
 			expect( octokit.issues.update ).toHaveBeenCalled();
 			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
-		it( 'patch bumpStrategy', async () => {
+		it( 'patch', async () => {
 			await app( context, octokit, {
 				bumpStrategy: 'patch',
 			} );
 			expect( octokit.issues.update ).toHaveBeenCalled();
 			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
-		it( 'minor bumpStrategy', async () => {
+		it( 'minor', async () => {
 			await app( context, octokit, {
 				bumpStrategy: 'minor',
 			} );
 			expect( octokit.issues.update ).toHaveBeenCalled();
 			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
-		it( 'major bumpStrategy', async () => {
+		it( 'major', async () => {
 			await app( context, octokit, {
 				bumpStrategy: 'major',
 			} );

--- a/lib/automations/assign-milestone/test/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/test/pull-request-review-handler.js
@@ -12,7 +12,9 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 			...context.payload,
 			review: { state: 'comment' },
 		};
-		await app( context, octokit );
+		await app( context, octokit, {
+			bumpStrategy: 'minor',
+		} );
 		expect( octokit.issues.update ).not.toHaveBeenCalled();
 	} );
 	it( 'does nothing if the pull request has a milestone', async () => {
@@ -20,7 +22,9 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 			...context.payload,
 			pull_request: { milestone: { number: 1 } },
 		};
-		await app( context, octokit );
+		await app( context, octokit, {
+			bumpStrategy: 'minor',
+		} );
 		expect( octokit.issues.update ).not.toHaveBeenCalled();
 	} );
 	it( 'assigns a milestone to an approved pull request', async () => {
@@ -36,11 +40,70 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 				},
 			} )
 		);
-		await app( context, octokit );
+		await app( context, octokit, {
+			bumpStrategy: 'minor',
+		} );
 		expect( octokit.repos.getContent ).toHaveBeenCalled();
 		expect(
 			octokit.issues.listMilestones.endpoint.merge
 		).toHaveBeenCalled();
+		expect( octokit.issues.update ).toHaveBeenCalled();
+		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
+	} );
+	it( 'ignore bumpStrategy', async () => {
+		octokit.repos.getContent.mockReturnValueOnce(
+			Promise.resolve( {
+				data: {
+					content: Buffer.from(
+						JSON.stringify( {
+							version: '3.0.0',
+						} )
+					).toString( 'base64' ),
+					encoding: 'base64',
+				},
+			} )
+		);
+		await app( context, octokit, {
+			bumpStrategy: 'ignore',
+		} );
+		expect( octokit.issues.update ).toHaveBeenCalled();
+		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
+	} );
+	it( 'minor bumpStrategy', async () => {
+		octokit.repos.getContent.mockReturnValueOnce(
+			Promise.resolve( {
+				data: {
+					content: Buffer.from(
+						JSON.stringify( {
+							version: '3.0.0',
+						} )
+					).toString( 'base64' ),
+					encoding: 'base64',
+				},
+			} )
+		);
+		await app( context, octokit, {
+			bumpStrategy: 'minor',
+		} );
+		expect( octokit.issues.update ).toHaveBeenCalled();
+		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
+	} );
+	it( 'major bumpStrategy', async () => {
+		octokit.repos.getContent.mockReturnValueOnce(
+			Promise.resolve( {
+				data: {
+					content: Buffer.from(
+						JSON.stringify( {
+							version: '3.0.0',
+						} )
+					).toString( 'base64' ),
+					encoding: 'base64',
+				},
+			} )
+		);
+		await app( context, octokit, {
+			bumpStrategy: 'major',
+		} );
 		expect( octokit.issues.update ).toHaveBeenCalled();
 		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 	} );

--- a/lib/automations/assign-milestone/test/pull-request-review-handler.js
+++ b/lib/automations/assign-milestone/test/pull-request-review-handler.js
@@ -50,61 +50,48 @@ describe( 'pull-request-review-handler assigns milestones to pull requests', () 
 		expect( octokit.issues.update ).toHaveBeenCalled();
 		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 	} );
-	it( 'ignore bumpStrategy', async () => {
-		octokit.repos.getContent.mockReturnValueOnce(
-			Promise.resolve( {
-				data: {
-					content: Buffer.from(
-						JSON.stringify( {
-							version: '3.0.0',
-						} )
-					).toString( 'base64' ),
-					encoding: 'base64',
-				},
-			} )
-		);
-		await app( context, octokit, {
-			bumpStrategy: 'ignore',
+	describe( 'pull-request-review-handler assigns correct milestone for bumpStrategy', () => {
+		beforeEach( () => {
+			octokit.repos.getContent.mockReturnValueOnce(
+				Promise.resolve( {
+					data: {
+						content: Buffer.from(
+							JSON.stringify( {
+								version: '3.0.0',
+							} )
+						).toString( 'base64' ),
+						encoding: 'base64',
+					},
+				} )
+			);
 		} );
-		expect( octokit.issues.update ).toHaveBeenCalled();
-		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
-	} );
-	it( 'minor bumpStrategy', async () => {
-		octokit.repos.getContent.mockReturnValueOnce(
-			Promise.resolve( {
-				data: {
-					content: Buffer.from(
-						JSON.stringify( {
-							version: '3.0.0',
-						} )
-					).toString( 'base64' ),
-					encoding: 'base64',
-				},
-			} )
-		);
-		await app( context, octokit, {
-			bumpStrategy: 'minor',
+		it( 'none bumpStrategy', async () => {
+			await app( context, octokit, {
+				bumpStrategy: 'none',
+			} );
+			expect( octokit.issues.update ).toHaveBeenCalled();
+			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
-		expect( octokit.issues.update ).toHaveBeenCalled();
-		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
-	} );
-	it( 'major bumpStrategy', async () => {
-		octokit.repos.getContent.mockReturnValueOnce(
-			Promise.resolve( {
-				data: {
-					content: Buffer.from(
-						JSON.stringify( {
-							version: '3.0.0',
-						} )
-					).toString( 'base64' ),
-					encoding: 'base64',
-				},
-			} )
-		);
-		await app( context, octokit, {
-			bumpStrategy: 'major',
+		it( 'patch bumpStrategy', async () => {
+			await app( context, octokit, {
+				bumpStrategy: 'patch',
+			} );
+			expect( octokit.issues.update ).toHaveBeenCalled();
+			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
 		} );
-		expect( octokit.issues.update ).toHaveBeenCalled();
-		expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
+		it( 'minor bumpStrategy', async () => {
+			await app( context, octokit, {
+				bumpStrategy: 'minor',
+			} );
+			expect( octokit.issues.update ).toHaveBeenCalled();
+			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
+		} );
+		it( 'major bumpStrategy', async () => {
+			await app( context, octokit, {
+				bumpStrategy: 'major',
+			} );
+			expect( octokit.issues.update ).toHaveBeenCalled();
+			expect( octokit.issues.update.mock.calls[ 0 ] ).toMatchSnapshot();
+		} );
 	} );
 } );

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,9 @@ const automations = require( './automations' );
 		);
 		return;
 	}
+
 	const token = getInput( 'github_token' );
+
 	if ( ! token ) {
 		setFailed( 'initialize: Input `github_token` is required' );
 		return;

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -118,8 +118,9 @@ exports.gimmeOctokit = () => {
 							return mockedAsyncIterator( [
 								{
 									data: [
-										{ title: '3.0.0', number: 1234 },
-										{ title: '3.1.0', number: 1235 },
+										{ title: '3.0.0', number: 300 },
+										{ title: '3.1.0', number: 310 },
+										{ title: '4.0.0', number: 400 },
 									],
 								},
 							] )();

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -119,6 +119,7 @@ exports.gimmeOctokit = () => {
 								{
 									data: [
 										{ title: '3.0.0', number: 300 },
+										{ title: '3.0.1', number: 301 },
 										{ title: '3.1.0', number: 310 },
 										{ title: '4.0.0', number: 400 },
 									],


### PR DESCRIPTION
Adds support for a new input named `milestone_bump_strategy` which determines which milestone is selected. none (current version), minor, major, or patch. Documented in the readme file.

@nerrad did suggest using a config array, however, this is not supported by the github actions.yml.

Testing by approving should use milestone_bump_strategy none, so the milestone will be whatever is currently in package.json.