### PR TITLE
Attach changelog to release automatically

### DIFF
--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -21,6 +21,7 @@ const {
 	getChangelogItems,
 	getDevNoteItems,
 } = require( '../../utils/changelog' );
+const attachChangelogToRelease = require( './utils/attach-changelog-to-release' );
 
 /**
  * @typedef {import('../../typedefs').GitHubContext} GitHubContext
@@ -116,6 +117,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		);
 		changelog = await getChangelog( changelogItems, config );
 		devNoteItems = getDevNoteItems( changelogItems, config );
+		await attachChangelogToRelease( context, octokit, changelog );
 	} catch ( e ) {
 		core.debug( `Error ${ e }` );
 		// @todo Handle re-attempting creation of changelog after resolving error.

--- a/lib/automations/release/test/branch-create-handler.js
+++ b/lib/automations/release/test/branch-create-handler.js
@@ -23,6 +23,8 @@ describe( 'branch-create-handler for release pull request generation', () => {
 		expect( octokit.paginate.iterator ).toHaveBeenCalled();
 		expect( octokit.issues.listForRepo.endpoint.merge ).toHaveBeenCalled();
 		expect( octokit.paginate.iterator ).toHaveBeenCalled();
+		expect( octokit.repos.listReleases ).toHaveBeenCalled();
+		expect( octokit.repos.updateRelease ).toHaveBeenCalled();
 		expect( octokit.pulls.create ).toHaveBeenCalled();
 		expect( octokit.issues.createComment ).toHaveBeenCalled();
 		expect( octokit.pulls.create.mock.calls[ 0 ] ).toMatchSnapshot();

--- a/lib/automations/release/utils/attach-changelog-to-release.js
+++ b/lib/automations/release/utils/attach-changelog-to-release.js
@@ -1,0 +1,21 @@
+const debug = require( '../../../debug' );
+
+const attachChangelogToRelease = async ( context, octokit, changelog ) => {
+	const releases = await octokit.repos.listReleases( {
+		...context.repo,
+	} );
+
+	if ( releases.data.length === 0 ) {
+		debug(
+			`releaseAutomation: No releases found for ${ context.repo.owner }/${ context.repo.repo }`
+		);
+	} else {
+		await octokit.repos.updateRelease( {
+			...context.repo,
+			release_id: releases.data[ 0 ].id,
+			body: changelog,
+		} );
+	}
+};
+
+module.exports = attachChangelogToRelease;

--- a/lib/automations/release/utils/test/attach-changelog-to-release.js
+++ b/lib/automations/release/utils/test/attach-changelog-to-release.js
@@ -1,0 +1,55 @@
+const attachChangelogToRelease = require( '../attach-changelog-to-release' );
+const releaseListPayload = require( '@testFixtures/payloads/release-list.json' );
+
+describe( 'attachChangelogToRelease', () => {
+	let context;
+
+	beforeEach( () => {
+		context = {
+			repo: {
+				owner: 'test-owner',
+				repo: 'test-repo',
+			},
+		};
+	} );
+
+	it( 'should update the release by adding the changelog if there is a release', async () => {
+		const octokit = {
+			repos: {
+				listReleases: jest
+					.fn( () =>
+						Promise.resolve( {
+							data: releaseListPayload,
+						} )
+					)
+					.mockName( 'repos.listReleases' ),
+				updateRelease: jest
+					.fn( () => Promise.resolve( {} ) )
+					.mockName( 'repos.updateRelease' ),
+			},
+		};
+
+		await attachChangelogToRelease( context, octokit );
+		expect( octokit.repos.listReleases ).toHaveBeenCalled();
+		expect( octokit.repos.updateRelease ).toHaveBeenCalled();
+	} );
+	it( "should not update the release if doesn't exists any release", async () => {
+		const octokit = {
+			repos: {
+				listReleases: jest
+					.fn( () =>
+						Promise.resolve( {
+							data: [],
+						} )
+					)
+					.mockName( 'repos.listReleases' ),
+				updateRelease: jest
+					.fn( () => Promise.resolve( {} ) )
+					.mockName( 'repos.updateRelease' ),
+			},
+		};
+
+		await attachChangelogToRelease( context, octokit );
+		expect( octokit.repos.listReleases ).toHaveBeenCalled();
+	} );
+} );

--- a/tests/fixtures/payloads/release-list.json
+++ b/tests/fixtures/payloads/release-list.json
@@ -1,0 +1,41 @@
+[
+	{
+		"url": "https://api.github.com/repos/gigitux/test-repo/releases/54476563",
+		"assets_url": "https://api.github.com/repos/gigitux/test-repo/releases/54476563/assets",
+		"upload_url": "https://uploads.github.com/repos/gigitux/test-repo/releases/54476563/assets{?name,label}",
+		"html_url": "https://github.com/gigitux/test-repo/releases/tag/1.0.0",
+		"id": 54476563,
+		"author": {
+			"login": "gigitux",
+			"id": 4463174,
+			"node_id": "MDQ6VXNlcjQ0NjMxNzQ=",
+			"avatar_url": "https://avatars.githubusercontent.com/u/4463174?v=4",
+			"gravatar_id": "",
+			"url": "https://api.github.com/users/gigitux",
+			"html_url": "https://github.com/gigitux",
+			"followers_url": "https://api.github.com/users/gigitux/followers",
+			"following_url": "https://api.github.com/users/gigitux/following{/other_user}",
+			"gists_url": "https://api.github.com/users/gigitux/gists{/gist_id}",
+			"starred_url": "https://api.github.com/users/gigitux/starred{/owner}{/repo}",
+			"subscriptions_url": "https://api.github.com/users/gigitux/subscriptions",
+			"organizations_url": "https://api.github.com/users/gigitux/orgs",
+			"repos_url": "https://api.github.com/users/gigitux/repos",
+			"events_url": "https://api.github.com/users/gigitux/events{/privacy}",
+			"received_events_url": "https://api.github.com/users/gigitux/received_events",
+			"type": "User",
+			"site_admin": false
+		},
+		"node_id": "RE_kwDOGdDvcs4DPz8T",
+		"tag_name": "1.0.0",
+		"target_commitish": "main",
+		"name": "1.0.0",
+		"draft": false,
+		"prerelease": false,
+		"created_at": "2021-12-01T17:05:23Z",
+		"published_at": "2021-12-02T09:16:06Z",
+		"assets": [],
+		"tarball_url": "https://api.github.com/repos/gigitux/test-repo/tarball/1.0.0",
+		"zipball_url": "https://api.github.com/repos/gigitux/test-repo/zipball/1.0.0",
+		"body": ""
+	}
+]

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,6 +1,8 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
+const releaseListPayload = require( '@testFixtures/payloads/release-list.json' );
+
 const loadDiff = ( exports.loadDiff = ( filename ) => {
 	return Promise.resolve( {
 		data: fs.readFileSync(
@@ -103,6 +105,16 @@ exports.gimmeOctokit = () => {
 				.fn( () => Promise.resolve( { data: { content: '' } } ) )
 				.mockName( 'repos.getContent' ),
 			getBranch: jest.fn().mockName( 'repos.getBranch' ),
+			listReleases: jest
+				.fn( () =>
+					Promise.resolve( {
+						data: releaseListPayload,
+					} )
+				)
+				.mockName( 'repos.listReleases' ),
+			updateRelease: jest
+				.fn( () => Promise.resolve( {} ) )
+				.mockName( 'repos.updateRelease' ),
 		},
 		pulls: {
 			get: jest.fn( () => loadDiff( 'basic' ) ).mockName( 'pulls.get' ),


### PR DESCRIPTION
This PR fixes woocommerce/woocommerce-gutenberg-products-block#4636

## Manual test

1. Create a new repo. You can start from [this template](https://github.com/gigitux/woocommerce-automation-test-repo).
2. Add a secret named `GITHUB_TOKEN` with a Github token with `repo` permission enabled.
2. Set a workflow for `woocoomerce-automation`. You can copy-paste [this file](https://github.com/gigitux/woocommerce-automation-test-repo/blob/main/.github/workflows/automation.yml). The important thing is to change the value `uses`. It has to point to this branch.
3. Create a new milestone and give the title a number version (eg: 1.0.0).
4. Create a PR with a changelog, assign the milestone created, and merge it ([example](https://github.com/gigitux/woocommerce-automation-test-repo/pull/36)).
5. Create a release with Github UI.
6. Now, create a new branch with this structure `release/{number_version}` (eg: 1.0.0) and push it.

Now the GitHub actions should be:
* create a new PR for the release.
* edit the description of the last release and add the changelog.

