### PR TITLE
Add testing instructions automatically on release PR

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -649,7 +649,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
-	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.tree.sha;
+	const testingInstructionsReadmeSha = testingInstructionsIndexResponse.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',

--- a/dist/index.js
+++ b/dist/index.js
@@ -3286,7 +3286,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		return error;
 	}
 	debug( JSON.stringify( changelog ) );
-	if ( ! pr.number in changelog ) {
+	if ( ! changelog.hasOwnProperty( pr.number ) && changelog[ pr.number ] ) {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -644,16 +644,19 @@ const branchHandler = async ( context, octokit, config ) => {
 	// new file before that.
 	let updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
-		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
+		`-   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionRegex = new RegExp(
+			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionLink,
+			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
 	}
@@ -663,9 +666,12 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionRegex = new RegExp(
+			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionLink,
+			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -654,7 +654,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
-		debug( JSON.stringify( `-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)` ) );
+		debug( lastReleaseVersionRegex );
 
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/dist/index.js
+++ b/dist/index.js
@@ -671,7 +671,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
 			updatedTestingInstructions = testingInstructionsIndexContents.replace(
 				/\n<!-- FEEDBACK -->/,
-				`${ newReleaseVersionLink }\n<!-- FEEDBACK -->`
+				`${ newReleaseVersionLink }\n\n<!-- FEEDBACK -->`
 			);
 		}
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -650,25 +650,23 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
-		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
-		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/dist/index.js
+++ b/dist/index.js
@@ -3196,9 +3196,9 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 		[...excludeFromTestingInstructionsPrIds, ...corePrIds, ...experimentalPrIds ],
 	);
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
-	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n#') } ` : '';
+	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) );
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n\n#') }` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(
@@ -3221,7 +3221,7 @@ ${ featurePluginTestingInstructions }` : '';
 	return `## Testing notes and ZIP for release ${ milestoneTitle }
 
 Zip file for testing: [insert link to built zip here]
-${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }${ unaccountedForPrMessage };
+${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }${ unaccountedForPrMessage }
 `;
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -656,8 +656,8 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
+
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
@@ -668,7 +668,6 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/dist/index.js
+++ b/dist/index.js
@@ -3198,7 +3198,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
 	const htmlUrl = context.payload.repository.html_url;
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }]( ${ htmlUrl }/pulls/${ id })` );
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pulls/${ id })` );
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(

--- a/dist/index.js
+++ b/dist/index.js
@@ -661,7 +661,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/dist/index.js
+++ b/dist/index.js
@@ -649,6 +649,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
+	debug( JSON.stringify( updatedReadmeCommit ) );
 	const updatedReadmeCommitSha = updatedReadmeCommit.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,

--- a/dist/index.js
+++ b/dist/index.js
@@ -643,7 +643,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	// Need to convert back to base64 to write to the repo.
 	const updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
-		`- [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n<!-- FEEDBACK -->`
+		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );

--- a/dist/index.js
+++ b/dist/index.js
@@ -655,7 +655,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		message: 'Update testing instructions in docs/testing/releases/README.md',
 		path: 'docs/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
-		sha: updatedReadmeCommitSha,
+		sha: testingInstructionsReadmeSha,
 		branch: context.payload.ref,
 	});
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3207,7 +3207,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 		)
 	);
 
-	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds, context );
+	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds, htmlUrl );
 	const coreTestingInstructions = corePrs.map( prTestingInstructionsMapFunc ).join( '' );
 	const featurePluginTestingInstructions = featurePluginPrs.map( prTestingInstructionsMapFunc ).join( '' );
 	const formattedCoreTestingInstructions = corePrs.length > 0 ?  `\n## Feature Plugin and package inclusion in WooCommerce

--- a/dist/index.js
+++ b/dist/index.js
@@ -3286,7 +3286,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		return error;
 	}
 	debug( JSON.stringify( changelog ) );
-	if ( ! pr.number.toString() in changelog ) {
+	if ( ! pr.number in changelog || ! changelog[ pr.number ] ) {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -670,6 +670,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
+		debug( JSON.stringify( lastReleaseVersionRegex ) );
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`

--- a/dist/index.js
+++ b/dist/index.js
@@ -649,11 +649,13 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
+	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.tree.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',
 		path: 'docs/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
+		sha: updatedReadmeCommitSha,
 		branch: context.payload.ref,
 	});
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -637,7 +637,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const testingInstructionsIndexBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
+	const testingInstructionsIndexBuffer = new Buffer.from( testingInstructionsIndexResponse.data.content, 'base64' );
 	const testingInstructionsIndexContents = testingInstructionsIndexBuffer.toString( 'utf-8' );
 
 	// Need to convert back to base64 to write to the repo.

--- a/dist/index.js
+++ b/dist/index.js
@@ -650,13 +650,13 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
-		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
@@ -668,7 +668,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/dist/index.js
+++ b/dist/index.js
@@ -660,11 +660,20 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionRegex,
-			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
-		);
+		if ( testingInstructionsIndexContents.indexOf( lastReleaseVersionLink ) >= 0 ) {
+			const newReleaseVersionLink = `    -   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
+			updatedTestingInstructions = testingInstructionsIndexContents.replace(
+				lastReleaseVersionRegex,
+				`${lastReleaseVersionLink}\n${newReleaseVersionLink}`
+			);
+		}
+		else {
+			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
+			updatedTestingInstructions = testingInstructionsIndexContents.replace(
+				/\w*<!-- FEEDBACK -->/,
+				`${newReleaseVersionLink}\n<!-- FEEDBACK -->`
+			);
+		}
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/dist/index.js
+++ b/dist/index.js
@@ -3290,7 +3290,6 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}
-	debug( `PR ${ pr.number } was found in changelog ${ JSON.stringify( changelog ) }. Extracting changelog then!` );
 	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3198,7 +3198,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
 	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs could not be categorised!\n\nPRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(' , #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(
@@ -3236,7 +3236,7 @@ const extractTestingInstructions = ( pr, changelog ) => {
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `# ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
+	const error = `### ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3287,6 +3287,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	}
 	debug( JSON.stringify( changelog ) );
 	if ( ! pr.number in changelog ) {
+		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}
 	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -595,6 +595,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
+	debug( JSON.stringify( context ) );
 	const readmeResponse = await octokit.repos.getContent({
 		...context.repo,
 		path: 'readme.txt',

--- a/dist/index.js
+++ b/dist/index.js
@@ -3239,7 +3239,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
 	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pull/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
-	if ( ! matches || ! matches[ 1 ] ) {
+	if ( ! matches || ! matches[ 1 ] || ! matches[1].trim() ) {
 		debug( error );
 		return error;
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -656,6 +656,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
@@ -667,6 +668,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/dist/index.js
+++ b/dist/index.js
@@ -3290,6 +3290,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}
+	debug( `PR ${ pr.number } was found in changelog ${ JSON.stringify( changelog ) }. Extracting changelog then!` );
 	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3285,6 +3285,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		debug( error );
 		return error;
 	}
+	debug( JSON.stringify( changelog ) );
 	if ( ! pr.number in changelog ) {
 		return error;
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -3198,7 +3198,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
 	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs could not be categorised!\n\nPRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(

--- a/dist/index.js
+++ b/dist/index.js
@@ -647,7 +647,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		`-   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
-	// If it's the first patch release then we need to add the line under x.x.0
+	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
 		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
 		let lastReleaseMinorVersion = '0';
@@ -655,7 +655,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
 		}
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
-		const lastReleaseVersionLink = `${ isFirstPatch ? '' : '   ' }-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/dist/index.js
+++ b/dist/index.js
@@ -670,8 +670,8 @@ const branchHandler = async ( context, octokit, config ) => {
 		else {
 			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
 			updatedTestingInstructions = testingInstructionsIndexContents.replace(
-				/\w*<!-- FEEDBACK -->/,
-				`${newReleaseVersionLink}\n<!-- FEEDBACK -->`
+				/\n\n<!-- FEEDBACK -->/,
+				`${ newReleaseVersionLink }\n<!-- FEEDBACK -->`
 			);
 		}
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -3218,8 +3218,7 @@ ${ featurePluginTestingInstructions }` : '';
 	return `## Testing notes and ZIP for release ${ milestoneTitle }
 
 Zip file for testing: [insert link to built zip here]
-${ formattedCoreTestingInstructions }
-${ formattedFeaturePluginTestingInstructions }
+${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }
 `;
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -650,11 +650,12 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
 		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
-		let lastReleaseMinorVersion = '0';
+		let lastReleasePatchVersion = '0';
+		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
 		if ( ! isFirstPatch ) {
-			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
+			lastReleasePatchVersion = parseInt( currentReleasePatchVersion ) - 1;
 		}
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
+		const lastReleaseVersion = `${ currentReleaseMajorVersion }.${ currentReleaseMinorVersion }.${ lastReleasePatchVersion }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`

--- a/dist/index.js
+++ b/dist/index.js
@@ -651,6 +651,8 @@ const branchHandler = async ( context, octokit, config ) => {
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		debug( JSON.stringify( lastReleaseVersionRegex ) );
+
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);

--- a/dist/index.js
+++ b/dist/index.js
@@ -630,10 +630,10 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const testingInstructionsIndexResponse = await octokit.repos.getContent({
 		...context.repo,
-		path: 'docs/testing/releases/README.md',
+		path: 'docs/internal-developers/testing/releases/README.md',
 	});
 	if ( ! testingInstructionsIndexResponse ) {
-		debug( `releaseAutomation: Could not read docs/testing/releases/README.md file from repository.` );
+		debug( `releaseAutomation: Could not read docs/internal/developers/testing/releases/README.md file from repository.` );
 		return;
 	}
 	// Content comes from GH API in base64 so convert it to utf-8 string.
@@ -684,15 +684,15 @@ const branchHandler = async ( context, octokit, config ) => {
 	const testingInstructionsReadmeSha = testingInstructionsIndexResponse.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
-		message: 'Update testing instructions in docs/testing/releases/README.md',
-		path: 'docs/testing/releases/README.md',
+		message: 'Update testing instructions in docs/internal-developers/testing/releases/README.md',
+		path: 'docs/internal-developers/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
 		sha: testingInstructionsReadmeSha,
 		branch: context.payload.ref,
 	});
 
 	if ( ! updatedTestingInstructionsIndexCommit ) {
-		debug( `releaseAutomation: Automatic update of docs/testing/releases/README.md failed.` );
+		debug( `releaseAutomation: Automatic update of docs/internal-developers/testing/releases/README.md failed.` );
 		return;
 	}
 
@@ -703,7 +703,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const newTestingInstructionsCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: `Add testing instructions for release ${ releaseVersion }`,
-		path: `docs/testing/releases/${ releaseTestingInstructionsFilename }.md`,
+		path: `docs/internal-developers/testing/releases/${ releaseTestingInstructionsFilename }.md`,
 		content: testingInstructions.toString( 'base64' ),
 		branch: context.payload.ref,
 	});

--- a/dist/index.js
+++ b/dist/index.js
@@ -653,10 +653,9 @@ const branchHandler = async ( context, octokit, config ) => {
 		let lastReleaseMinorVersion = '0';
 		if ( ! isFirstPatch ) {
 			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
-
 		}
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
-		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = `${ isFirstPatch ? '' : '   ' }-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/dist/index.js
+++ b/dist/index.js
@@ -649,9 +649,9 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
-		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
-		let lastReleasePatchVersion = '0';
 		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
+		const isFirstPatch = currentReleasePatchVersion === '1';
+		let lastReleasePatchVersion = '0';
 		if ( ! isFirstPatch ) {
 			lastReleasePatchVersion = parseInt( currentReleasePatchVersion ) - 1;
 		}
@@ -3249,7 +3249,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(
-		[ ...corePrs, ...featurePluginPrs ].map(
+		[ ...corePrs, ...featurePluginPrs, ...experimentalPrIds ].map(
 			( pr ) => ( [ pr.number, getChangelogEntry( pr ) ] )
 		)
 	);

--- a/dist/index.js
+++ b/dist/index.js
@@ -651,11 +651,11 @@ const branchHandler = async ( context, octokit, config ) => {
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
-		debug( JSON.stringify( lastReleaseVersionRegex ) );
-
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
+		debug( JSON.stringify( lastReleaseVersionRegex ) );
+
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionRegex,

--- a/dist/index.js
+++ b/dist/index.js
@@ -650,12 +650,16 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
 		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
-		const isFirstPatch = currentReleasePatchVersion === '1';
-		let lastReleasePatchVersion = '0';
-		if ( ! isFirstPatch ) {
-			lastReleasePatchVersion = parseInt( currentReleasePatchVersion ) - 1;
-		}
-		const lastReleaseVersion = `${ currentReleaseMajorVersion }.${ currentReleaseMinorVersion }.${ lastReleasePatchVersion }`;
+
+		const releasesForSameMajorVersion = testingInstructionsIndexContents
+			.match( new RegExp( `\\[${ currentReleaseMajorVersion }\\.\\d+\\.\\d+\\]`, 'img' ) )
+			.map( version => version.replace( /\[|\]/g, '' ).split( '.' ) );
+
+		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
+		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => b[2] - a[2] );
+		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => release[2] < currentReleasePatchVersion );
+
+		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`

--- a/dist/index.js
+++ b/dist/index.js
@@ -666,21 +666,6 @@ const branchHandler = async ( context, octokit, config ) => {
 		);
 	}
 
-	// If it's NOT the first patch release then we need to add the line under x.x.x
-	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
-		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
-		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
-		const lastReleaseVersionRegex = new RegExp(
-			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
-		);
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionRegex,
-			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
-		);
-	}
-
 	// Create a buffer so we can convert it to base64 in the next step.
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );

--- a/dist/index.js
+++ b/dist/index.js
@@ -649,8 +649,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
-	debug( JSON.stringify( updatedReadmeCommit ) );
-	const updatedReadmeCommitSha = updatedReadmeCommit.data.sha;
+	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',

--- a/dist/index.js
+++ b/dist/index.js
@@ -670,7 +670,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		else {
 			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
 			updatedTestingInstructions = testingInstructionsIndexContents.replace(
-				/\n\n<!-- FEEDBACK -->/,
+				/\n<!-- FEEDBACK -->/,
 				`${ newReleaseVersionLink }\n<!-- FEEDBACK -->`
 			);
 		}

--- a/dist/index.js
+++ b/dist/index.js
@@ -3198,7 +3198,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
 	const htmlUrl = context.payload.repository.html_url;
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pulls/${ id })` );
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pull/${ id })` );
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(
@@ -3238,7 +3238,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pulls/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
+	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pull/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/dist/index.js
+++ b/dist/index.js
@@ -656,7 +656,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			.map( version => version.replace( /\[|\]/g, '' ).split( '.' ) );
 
 		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
-		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => b[2] - a[2] );
+		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => parseInt( b[2] ) - parseInt( a[2] ) );
 		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => release[2] < currentReleasePatchVersion );
 
 		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -649,13 +649,11 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
-	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',
 		path: 'docs/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
-		sha: updatedReadmeCommitSha,
 		branch: context.payload.ref,
 	});
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3198,7 +3198,7 @@ const getTestingInstructions = async ( context, octokit, milestoneTitle, config 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
 	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(' , #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n#') } ` : '';
 	const getChangelogEntry = (0,_changelog__WEBPACK_IMPORTED_MODULE_0__.getEntry)( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(

--- a/dist/index.js
+++ b/dist/index.js
@@ -3286,7 +3286,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		return error;
 	}
 	debug( JSON.stringify( changelog ) );
-	if ( ! changelog.hasOwnProperty( pr.number ) && changelog[ pr.number ] ) {
+	if ( ! pr.number.toString() in changelog ) {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}

--- a/dist/index.js
+++ b/dist/index.js
@@ -649,8 +649,29 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) ) {
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
+		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
+		let lastReleaseMinorVersion = '0';
+		if ( ! isFirstPatch ) {
+			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
+
+		}
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionRegex = new RegExp(
+			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
+		);
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
+		updatedTestingInstructions = testingInstructionsIndexContents.replace(
+			lastReleaseVersionRegex,
+			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
+		);
+	}
+
+	// If it's NOT the first patch release then we need to add the line under x.x.x
+	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
+		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
+		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/dist/index.js
+++ b/dist/index.js
@@ -657,7 +657,7 @@ const branchHandler = async ( context, octokit, config ) => {
 
 		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
 		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => parseInt( b[2] ) - parseInt( a[2] ) );
-		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => release[2] < currentReleasePatchVersion );
+		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => parseInt( release[2] ) < parseInt( currentReleasePatchVersion ) );
 
 		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -642,10 +642,32 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// The last line of the file is not the last entry, it is the FEEDBACK section, so we need to insert the link to the
 	// new file before that.
-	const updatedTestingInstructions = testingInstructionsIndexContents.replace(
+	let updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
 		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
+
+	// If it's the first patch release then we need to add the line under x.x.0
+	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
+		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		updatedTestingInstructions = testingInstructionsIndexContents.replace(
+			lastReleaseVersionLink,
+			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
+		);
+	}
+	// If it's NOT the first patch release then we need to add the line under x.x.x
+	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
+		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
+		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		updatedTestingInstructions = testingInstructionsIndexContents.replace(
+			lastReleaseVersionLink,
+			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
+		);
+	}
 
 	// Create a buffer so we can convert it to base64 in the next step.
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );

--- a/dist/index.js
+++ b/dist/index.js
@@ -652,7 +652,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
 		debug( lastReleaseVersionRegex );
 
@@ -669,10 +669,9 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		debug( JSON.stringify( lastReleaseVersionRegex ) );
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`

--- a/dist/index.js
+++ b/dist/index.js
@@ -3236,7 +3236,7 @@ const extractTestingInstructions = ( pr, changelog ) => {
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!`
+	const error = `# ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/dist/index.js
+++ b/dist/index.js
@@ -654,7 +654,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
-		debug( JSON.stringify( lastReleaseVersionRegex ) );
+		debug( JSON.stringify( `-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)` ) );
 
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/dist/index.js
+++ b/dist/index.js
@@ -648,26 +648,9 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 
 	// If it's the first patch release then we need to add the line under x.x.0
-	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
+	if ( isPatchRelease( releaseVersion ) ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
-		const lastReleaseVersionRegex = new RegExp(
-			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
-		);
-		debug( lastReleaseVersionRegex );
-
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionRegex,
-			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
-		);
-	}
-
-	// If it's NOT the first patch release then we need to add the line under x.x.x
-	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
-		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
-		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/dist/index.js
+++ b/dist/index.js
@@ -652,7 +652,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
 		debug( lastReleaseVersionRegex );
 
@@ -669,7 +669,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -236,7 +236,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
-		debug( JSON.stringify( `-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)` ) );
+		debug( lastReleaseVersionRegex );
 
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -226,16 +226,19 @@ const branchHandler = async ( context, octokit, config ) => {
 	// new file before that.
 	let updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
-		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
+		`-   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionRegex = new RegExp(
+			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionLink,
+			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
 	}
@@ -245,9 +248,12 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionRegex = new RegExp(
+			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionLink,
+			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
 	}

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -236,7 +236,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
-		debug( JSON.stringify( lastReleaseVersionRegex ) );
+		debug( JSON.stringify( `-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)` ) );
 
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,11 +231,13 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
+	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.tree.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',
 		path: 'docs/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
+		sha: updatedReadmeCommitSha,
 		branch: context.payload.ref,
 	});
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -238,7 +238,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			.map( version => version.replace( /\[|\]/g, '' ).split( '.' ) );
 
 		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
-		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => b[2] - a[2] );
+		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => parseInt( b[2] ) - parseInt( a[2] ) );
 		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => release[2] < currentReleasePatchVersion );
 
 		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -21,6 +21,7 @@ const {
 	getChangelogItems,
 	getDevNoteItems,
 } = require( '../../utils/changelog' );
+const {getTestingInstructions} = require('../../utils/testing-instructions');
 
 /**
  * @typedef {import('../../typedefs').GitHubContext} GitHubContext
@@ -206,6 +207,22 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	if ( ! updatedReadmeCommit ) {
 		debug( `releaseAutomation: Automatic update of readme failed.` );
+		return;
+	}
+
+	const testingInstructions = new Buffer.from( await getTestingInstructions( context, octokit, releaseVersion, config ), 'utf-8' );
+	debug( testingInstructions.toString() );
+	debug( testingInstructions.toString( 'base64') );
+	const releaseTestingInstructionsFilename = releaseVersion.replace(/\./g, '' );
+	const newTestingInstructionsCommit = await octokit.repos.createOrUpdateFileContents({
+		...context.repo,
+		message: `Add testing instructions for release ${ releaseVersion }`,
+		path: `docs/testing/releases/${ releaseTestingInstructionsFilename }.md`,
+		content: testingInstructions.toString( 'base64' ),
+		branch: context.payload.ref,
+	});
+	if ( ! newTestingInstructionsCommit ) {
+		debug( `releaseAutomation: Automatic creation of testing instructions failed.` );
 		return;
 	}
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -252,7 +252,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		else {
 			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
 			updatedTestingInstructions = testingInstructionsIndexContents.replace(
-				/\n\n<!-- FEEDBACK -->/,
+				/\n<!-- FEEDBACK -->/,
 				`${ newReleaseVersionLink }\n<!-- FEEDBACK -->`
 			);
 		}

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -234,7 +234,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
 		debug( lastReleaseVersionRegex );
 
@@ -251,7 +251,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -177,6 +177,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
+	debug( JSON.stringify( context ) );
 	const readmeResponse = await octokit.repos.getContent({
 		...context.repo,
 		path: 'readme.txt',

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -222,15 +222,18 @@ const branchHandler = async ( context, octokit, config ) => {
 	const testingInstructionsIndexBuffer = new Buffer.from( testingInstructionsIndexResponse.data.content, 'base64' );
 	const testingInstructionsIndexContents = testingInstructionsIndexBuffer.toString( 'utf-8' );
 
-	// Need to convert back to base64 to write to the repo.
+	// The last line of the file is not the last entry, it is the FEEDBACK section, so we need to insert the link to the
+	// new file before that.
 	const updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
 		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
+	// Create a buffer so we can convert it to base64 in the next step.
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
+	// We need this sha to commit the updated content back to the repository.
 	const testingInstructionsReadmeSha = testingInstructionsIndexResponse.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
@@ -247,9 +250,9 @@ const branchHandler = async ( context, octokit, config ) => {
 	}
 
 	const testingInstructions = new Buffer.from( await getTestingInstructions( context, octokit, releaseVersion, config ), 'utf-8' );
-	debug( testingInstructions.toString() );
-	debug( testingInstructions.toString( 'base64') );
 	const releaseTestingInstructionsFilename = releaseVersion.replace(/\./g, '' );
+
+	// No need for a sha here since it's a new file.
 	const newTestingInstructionsCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: `Add testing instructions for release ${ releaseVersion }`,
@@ -257,6 +260,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		content: testingInstructions.toString( 'base64' ),
 		branch: context.payload.ref,
 	});
+
 	if ( ! newTestingInstructionsCommit ) {
 		debug( `releaseAutomation: Automatic creation of testing instructions failed.` );
 		return;

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -252,8 +252,8 @@ const branchHandler = async ( context, octokit, config ) => {
 		else {
 			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
 			updatedTestingInstructions = testingInstructionsIndexContents.replace(
-				/\w*<!-- FEEDBACK -->/,
-				`${newReleaseVersionLink}\n<!-- FEEDBACK -->`
+				/\n\n<!-- FEEDBACK -->/,
+				`${ newReleaseVersionLink }\n<!-- FEEDBACK -->`
 			);
 		}
 	}

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -225,7 +225,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	// Need to convert back to base64 to write to the repo.
 	const updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
-		`- [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n<!-- FEEDBACK -->`
+		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -210,6 +210,42 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
+	const testingInstructionsIndexResponse = await octokit.repos.getContent({
+		...context.repo,
+		path: 'docs/testing/releases/README.md',
+	});
+	if ( ! testingInstructionsIndexResponse ) {
+		debug( `releaseAutomation: Could not read docs/testing/releases/README.md file from repository.` );
+		return;
+	}
+	// Content comes from GH API in base64 so convert it to utf-8 string.
+	const testingInstructionsIndexBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
+	const testingInstructionsIndexContents = testingInstructionsIndexBuffer.toString( 'utf-8' );
+
+	// Need to convert back to base64 to write to the repo.
+	const updatedTestingInstructions = testingInstructionsIndexContents.replace(
+		'\n<!-- FEEDBACK -->',
+		`- [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n<!-- FEEDBACK -->`
+	);
+
+	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
+	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
+
+	const updatedReadmeCommitSha = updatedReadmeCommit.data.sha;
+	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
+		...context.repo,
+		message: 'Update testing instructions in docs/testing/releases/README.md',
+		path: 'docs/testing/releases/README.md',
+		content: updatedTestingInstructionsContent,
+		sha: updatedReadmeCommitSha,
+		branch: context.payload.ref,
+	});
+
+	if ( ! updatedTestingInstructionsIndexCommit ) {
+		debug( `releaseAutomation: Automatic update of docs/testing/releases/README.md failed.` );
+		return;
+	}
+
 	const testingInstructions = new Buffer.from( await getTestingInstructions( context, octokit, releaseVersion, config ), 'utf-8' );
 	debug( testingInstructions.toString() );
 	debug( testingInstructions.toString( 'base64') );

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -233,6 +233,8 @@ const branchHandler = async ( context, octokit, config ) => {
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		debug( JSON.stringify( lastReleaseVersionRegex ) );
+
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -230,26 +230,9 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 
 	// If it's the first patch release then we need to add the line under x.x.0
-	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
+	if ( isPatchRelease( releaseVersion ) ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
-		const lastReleaseVersionRegex = new RegExp(
-			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
-		);
-		debug( lastReleaseVersionRegex );
-
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionRegex,
-			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
-		);
-	}
-
-	// If it's NOT the first patch release then we need to add the line under x.x.x
-	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
-		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
-		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -234,7 +234,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
 		debug( lastReleaseVersionRegex );
 
@@ -251,10 +251,9 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
-			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
+			`-\s*\[${ lastReleaseVersion }\]\(\.\/${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		debug( JSON.stringify( lastReleaseVersionRegex ) );
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -237,7 +237,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		message: 'Update testing instructions in docs/testing/releases/README.md',
 		path: 'docs/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
-		sha: updatedReadmeCommitSha,
+		sha: testingInstructionsReadmeSha,
 		branch: context.payload.ref,
 	});
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -238,6 +238,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
@@ -249,6 +250,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,6 +231,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
+	debug( JSON.stringify( updatedReadmeCommit ) );
 	const updatedReadmeCommitSha = updatedReadmeCommit.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,8 +231,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
-	debug( JSON.stringify( updatedReadmeCommit ) );
-	const updatedReadmeCommitSha = updatedReadmeCommit.data.sha;
+	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,8 +231,29 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) ) {
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
+		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
+		let lastReleaseMinorVersion = '0';
+		if ( ! isFirstPatch ) {
+			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
+
+		}
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionRegex = new RegExp(
+			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
+		);
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
+		updatedTestingInstructions = testingInstructionsIndexContents.replace(
+			lastReleaseVersionRegex,
+			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
+		);
+	}
+
+	// If it's NOT the first patch release then we need to add the line under x.x.x
+	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
+		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
+		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,13 +231,11 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
-	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',
 		path: 'docs/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
-		sha: updatedReadmeCommitSha,
 		branch: context.payload.ref,
 	});
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -239,7 +239,7 @@ const branchHandler = async ( context, octokit, config ) => {
 
 		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
 		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => parseInt( b[2] ) - parseInt( a[2] ) );
-		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => release[2] < currentReleasePatchVersion );
+		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => parseInt( release[2] ) < parseInt( currentReleasePatchVersion ) );
 
 		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -177,7 +177,6 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
-	debug( JSON.stringify( context ) );
 	const readmeResponse = await octokit.repos.getContent({
 		...context.repo,
 		path: 'readme.txt',

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -242,11 +242,20 @@ const branchHandler = async ( context, octokit, config ) => {
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionRegex,
-			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
-		);
+		if ( testingInstructionsIndexContents.indexOf( lastReleaseVersionLink ) >= 0 ) {
+			const newReleaseVersionLink = `    -   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
+			updatedTestingInstructions = testingInstructionsIndexContents.replace(
+				lastReleaseVersionRegex,
+				`${lastReleaseVersionLink}\n${newReleaseVersionLink}`
+			);
+		}
+		else {
+			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
+			updatedTestingInstructions = testingInstructionsIndexContents.replace(
+				/\w*<!-- FEEDBACK -->/,
+				`${newReleaseVersionLink}\n<!-- FEEDBACK -->`
+			);
+		}
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,7 +231,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );
 
-	const updatedReadmeCommitSha = updatedReadmeCommit.data.commit.tree.sha;
+	const testingInstructionsReadmeSha = testingInstructionsIndexResponse.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: 'Update testing instructions in docs/testing/releases/README.md',

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -243,7 +243,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
 		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -232,12 +232,16 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
 		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
-		const isFirstPatch = currentReleasePatchVersion === '1';
-		let lastReleasePatchVersion = '0';
-		if ( ! isFirstPatch ) {
-			lastReleasePatchVersion = parseInt( currentReleasePatchVersion ) - 1;
-		}
-		const lastReleaseVersion = `${ currentReleaseMajorVersion }.${ currentReleaseMinorVersion }.${ lastReleasePatchVersion }`;
+
+		const releasesForSameMajorVersion = testingInstructionsIndexContents
+			.match( new RegExp( `\\[${ currentReleaseMajorVersion }\\.\\d+\\.\\d+\\]`, 'img' ) )
+			.map( version => version.replace( /\[|\]/g, '' ).split( '.' ) );
+
+		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
+		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => b[2] - a[2] );
+		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => release[2] < currentReleasePatchVersion );
+
+		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -229,7 +229,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		`-   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
 
-	// If it's the first patch release then we need to add the line under x.x.0
+	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
 		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
 		let lastReleaseMinorVersion = '0';
@@ -237,7 +237,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
 		}
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
-		const lastReleaseVersionLink = `${ isFirstPatch ? '' : '   ' }-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -232,13 +232,13 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
-		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
@@ -250,7 +250,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
+		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -232,11 +232,12 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
 		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
-		let lastReleaseMinorVersion = '0';
+		let lastReleasePatchVersion = '0';
+		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
 		if ( ! isFirstPatch ) {
-			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
+			lastReleasePatchVersion = parseInt( currentReleasePatchVersion ) - 1;
 		}
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
+		const lastReleaseVersion = `${ currentReleaseMajorVersion }.${ currentReleaseMinorVersion }.${ lastReleasePatchVersion }`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -224,10 +224,32 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// The last line of the file is not the last entry, it is the FEEDBACK section, so we need to insert the link to the
 	// new file before that.
-	const updatedTestingInstructions = testingInstructionsIndexContents.replace(
+	let updatedTestingInstructions = testingInstructionsIndexContents.replace(
 		'\n<!-- FEEDBACK -->',
 		`-\t[${ releaseVersion }](./${ releaseVersion.replace( /\./g, '') }.md)\n\n<!-- FEEDBACK -->`
 	);
+
+	// If it's the first patch release then we need to add the line under x.x.0
+	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
+		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		updatedTestingInstructions = testingInstructionsIndexContents.replace(
+			lastReleaseVersionLink,
+			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
+		);
+	}
+	// If it's NOT the first patch release then we need to add the line under x.x.x
+	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
+		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
+		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
+		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		updatedTestingInstructions = testingInstructionsIndexContents.replace(
+			lastReleaseVersionLink,
+			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
+		);
+	}
 
 	// Create a buffer so we can convert it to base64 in the next step.
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -253,7 +253,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			const newReleaseVersionLink = `-   [${releaseVersion}](./${releaseVersion.replace(/\./g, '')}.md)`;
 			updatedTestingInstructions = testingInstructionsIndexContents.replace(
 				/\n<!-- FEEDBACK -->/,
-				`${ newReleaseVersionLink }\n<!-- FEEDBACK -->`
+				`${ newReleaseVersionLink }\n\n<!-- FEEDBACK -->`
 			);
 		}
 	}

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -252,6 +252,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
+		debug( JSON.stringify( lastReleaseVersionRegex ) );
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionRegex,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -235,10 +235,9 @@ const branchHandler = async ( context, octokit, config ) => {
 		let lastReleaseMinorVersion = '0';
 		if ( ! isFirstPatch ) {
 			lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) ) - 1;
-
 		}
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
-		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = `${ isFirstPatch ? '' : '   ' }-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,18 +231,12 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
-		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
-
-		const releasesForSameMajorVersion = testingInstructionsIndexContents
-			.match( new RegExp( `\\[${ currentReleaseMajorVersion }\\.\\d+\\.\\d+\\]`, 'img' ) )
-			.map( version => version.replace( /\[|\]/g, '' ).split( '.' ) );
-
-		const releasesForSameMinorVersion = releasesForSameMajorVersion.filter( release => release[1] === currentReleaseMinorVersion );
-		const releasesOrderedByPatchVersion = releasesForSameMinorVersion.sort( ( a, b ) => parseInt( b[2] ) - parseInt( a[2] ) );
-		const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion.find( release => parseInt( release[2] ) < parseInt( currentReleasePatchVersion ) );
-
-		const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;
-		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const lastReleaseVersionLink = getLastPatchReleaseVersionLink(
+			{
+				releaseVersion,
+				testingInstructionsIndexContents
+			}
+		);
 		const lastReleaseVersionRegex = new RegExp(
 			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
 		);
@@ -310,6 +304,30 @@ const branchHandler = async ( context, octokit, config ) => {
 		body: commentBody,
 	} );
 };
+
+/**
+ * Get the last patch release version link from the testing instructions index.
+ * @param releaseVersion - The current version being released.
+ * @param testingInstructionsIndexContents - The contents of the testing instructions index.
+ * @return {`-   [${string}](./${string}.md)`} - The last patch release version link.
+ */
+const getLastPatchReleaseVersionLink = ( { releaseVersion, testingInstructionsIndexContents } ) => {
+	const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
+
+	const releasesForSameMajorVersion = testingInstructionsIndexContents
+		.match( new RegExp( `\\[${ currentReleaseMajorVersion }\\.\\d+\\.\\d+\\]`, 'img' ) )
+		.map( version => version.replace( /\[|\]/g, '' ).split( '.' ) );
+
+	const releasesForSameMinorVersion = releasesForSameMajorVersion
+		.filter( ( release ) => release[1] === currentReleaseMinorVersion );
+	const releasesOrderedByPatchVersion = releasesForSameMinorVersion
+		.sort( ( a, b ) => parseInt( b[2] ) - parseInt( a[2] ) );
+	const patchReleaseBeforeCurrentRelease = releasesOrderedByPatchVersion
+		.find( ( release ) => parseInt( release[2] ) < parseInt( currentReleasePatchVersion ) );
+
+	const lastReleaseVersion = `${ patchReleaseBeforeCurrentRelease[0] }.${ patchReleaseBeforeCurrentRelease[1] }.${ patchReleaseBeforeCurrentRelease[2] }`;
+	return `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+}
 
 /**
  * @param {GitHubContext} context

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -248,21 +248,6 @@ const branchHandler = async ( context, octokit, config ) => {
 		);
 	}
 
-	// If it's NOT the first patch release then we need to add the line under x.x.x
-	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
-		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
-		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion - 1 }`;
-		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
-		const lastReleaseVersionRegex = new RegExp(
-			`-\\s*\\[${ lastReleaseVersion.replace( /\./g, '\\.') }\\]\\(\\.\\/${ lastReleaseVersion.replace( /\./g, '' ) }\\.md\\)`
-		);
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
-		updatedTestingInstructions = testingInstructionsIndexContents.replace(
-			lastReleaseVersionRegex,
-			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
-		);
-	}
-
 	// Create a buffer so we can convert it to base64 in the next step.
 	const updatedTestingInstructionsIndexBuffer = new Buffer.from( updatedTestingInstructions, 'utf-8' );
 	const updatedTestingInstructionsContent = updatedTestingInstructionsIndexBuffer.toString( 'base64' );

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -219,7 +219,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const testingInstructionsIndexBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
+	const testingInstructionsIndexBuffer = new Buffer.from( testingInstructionsIndexResponse.data.content, 'base64' );
 	const testingInstructionsIndexContents = testingInstructionsIndexBuffer.toString( 'utf-8' );
 
 	// Need to convert back to base64 to write to the repo.

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -231,9 +231,9 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	// If it's the first patch release then we need to add the line under x.x.0 if it's not then add it under x.x.x (last release)
 	if ( isPatchRelease( releaseVersion ) ) {
-		const isFirstPatch = releaseVersion.charAt( releaseVersion.length - 1 ) === '1';
-		let lastReleasePatchVersion = '0';
 		const [ currentReleaseMajorVersion, currentReleaseMinorVersion, currentReleasePatchVersion ] = releaseVersion.split( '.' );
+		const isFirstPatch = currentReleasePatchVersion === '1';
+		let lastReleasePatchVersion = '0';
 		if ( ! isFirstPatch ) {
 			lastReleasePatchVersion = parseInt( currentReleasePatchVersion ) - 1;
 		}

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -212,10 +212,10 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const testingInstructionsIndexResponse = await octokit.repos.getContent({
 		...context.repo,
-		path: 'docs/testing/releases/README.md',
+		path: 'docs/internal-developers/testing/releases/README.md',
 	});
 	if ( ! testingInstructionsIndexResponse ) {
-		debug( `releaseAutomation: Could not read docs/testing/releases/README.md file from repository.` );
+		debug( `releaseAutomation: Could not read docs/internal/developers/testing/releases/README.md file from repository.` );
 		return;
 	}
 	// Content comes from GH API in base64 so convert it to utf-8 string.
@@ -266,15 +266,15 @@ const branchHandler = async ( context, octokit, config ) => {
 	const testingInstructionsReadmeSha = testingInstructionsIndexResponse.data.sha;
 	const updatedTestingInstructionsIndexCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
-		message: 'Update testing instructions in docs/testing/releases/README.md',
-		path: 'docs/testing/releases/README.md',
+		message: 'Update testing instructions in docs/internal-developers/testing/releases/README.md',
+		path: 'docs/internal-developers/testing/releases/README.md',
 		content: updatedTestingInstructionsContent,
 		sha: testingInstructionsReadmeSha,
 		branch: context.payload.ref,
 	});
 
 	if ( ! updatedTestingInstructionsIndexCommit ) {
-		debug( `releaseAutomation: Automatic update of docs/testing/releases/README.md failed.` );
+		debug( `releaseAutomation: Automatic update of docs/internal-developers/testing/releases/README.md failed.` );
 		return;
 	}
 
@@ -285,7 +285,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const newTestingInstructionsCommit = await octokit.repos.createOrUpdateFileContents({
 		...context.repo,
 		message: `Add testing instructions for release ${ releaseVersion }`,
-		path: `docs/testing/releases/${ releaseTestingInstructionsFilename }.md`,
+		path: `docs/internal-developers/testing/releases/${ releaseTestingInstructionsFilename }.md`,
 		content: testingInstructions.toString( 'base64' ),
 		branch: context.payload.ref,
 	});

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -232,25 +232,23 @@ const branchHandler = async ( context, octokit, config ) => {
 	// If it's the first patch release then we need to add the line under x.x.0
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
-		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		const lastReleaseVersionLink = `-    [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }${ lastReleaseMinorVersion }`;
-		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./, '' ) }.md)`;
-		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./, '' ) }.md)`;
+		const lastReleaseVersionLink = `    -   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
+		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -233,11 +233,11 @@ const branchHandler = async ( context, octokit, config ) => {
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) === '1' ) {
 		const lastReleaseVersion = `${ releaseVersion.substr( 0, releaseVersion.length - 1 ) }0`;
 		const lastReleaseVersionLink = `-   [${ lastReleaseVersion }](./${ lastReleaseVersion.replace( /\./g, '' ) }.md)`;
-		debug( JSON.stringify( lastReleaseVersionRegex ) );
-
 		const lastReleaseVersionRegex = new RegExp(
 			`-\s*\[${ lastReleaseVersion }\]\(\./${ lastReleaseVersion.replace( /\./g, '' ) }.md\)`
 		);
+		debug( JSON.stringify( lastReleaseVersionRegex ) );
+
 		const newReleaseVersionLink = `    -   [${ releaseVersion }](./${ releaseVersion.replace( /\./g, '' ) }.md)`;
 		updatedTestingInstructions = testingInstructionsIndexContents.replace(
 			lastReleaseVersionRegex,

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -238,8 +238,8 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
+
 	// If it's NOT the first patch release then we need to add the line under x.x.x
 	if ( isPatchRelease( releaseVersion ) && releaseVersion.charAt( releaseVersion.length - 1 ) !== '1' ) {
 		const lastReleaseMinorVersion = parseInt( releaseVersion.charAt( releaseVersion.length - 1 ) );
@@ -250,7 +250,6 @@ const branchHandler = async ( context, octokit, config ) => {
 			lastReleaseVersionLink,
 			`${ lastReleaseVersionLink }\n${ newReleaseVersionLink }`
 		);
-		debug( JSON.stringify({lastReleaseVersionLink, lastReleaseVersion, newReleaseVersionLink, updatedTestingInstructions}) );
 	}
 
 	// Create a buffer so we can convert it to base64 in the next step.

--- a/lib/utils/changelog/common/changelog.js
+++ b/lib/utils/changelog/common/changelog.js
@@ -499,6 +499,8 @@ module.exports = {
 	getNormalizedTitle,
 	getIssueType,
 	sortGroup,
+	getEntry,
+	fetchAllPullRequests,
 	getTypesByLabels,
 	getTypesByTitle,
 	getChangelogItems,

--- a/lib/utils/changelog/index.js
+++ b/lib/utils/changelog/index.js
@@ -1,10 +1,14 @@
 const {
+	fetchAllPullRequests,
+	getEntry,
 	getChangelog,
 	getDevNoteItems,
 	getChangelogItems,
 } = require( './common/changelog' );
 
 module.exports = {
+	fetchAllPullRequests,
+	getEntry,
 	getChangelog,
 	getDevNoteItems,
 	getChangelogItems,

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -51,7 +51,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
 	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs could not be categorised!\n\nPRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -60,7 +60,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 		)
 	);
 
-	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds, context );
+	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds, htmlUrl );
 	const coreTestingInstructions = corePrs.map( prTestingInstructionsMapFunc ).join( '' );
 	const featurePluginTestingInstructions = featurePluginPrs.map( prTestingInstructionsMapFunc ).join( '' );
 	const formattedCoreTestingInstructions = corePrs.length > 0 ?  `\n## Feature Plugin and package inclusion in WooCommerce

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -22,33 +22,36 @@ const debug = require( '../debug' );
  */
 export const getTestingInstructions = async ( context, octokit, milestoneTitle, config ) => {
 	const prList = await fetchAllPullRequests( context, octokit, milestoneTitle);
+	const allPrIds = prList.map( ( pr ) => pr.number );
 
 	const doNotIncludeInTestingInstructionsPrs = getPrsMatchingText(
 		prList,
 		( body ) => body.includes( '* [x] Do not include in the Testing Notes' ),
 	);
-	const excludeFromTestingInstructionsIds = doNotIncludeInTestingInstructionsPrs.map( (pr) => pr.number );
+	const excludeFromTestingInstructionsPrIds = doNotIncludeInTestingInstructionsPrs.map( (pr) => pr.number );
 
 	const experimentalPrs = getPrsMatchingText(
 		prList,
 		( body ) => body.includes( '* [x] Experimental' ),
-		excludeFromTestingInstructionsIds,
+		excludeFromTestingInstructionsPrIds,
 	);
 	const experimentalPrIds = experimentalPrs.map( ( pr ) => pr.number );
-
 
 	const corePrs = getPrsMatchingText(
 		prList,
 		( body ) => body.includes( '* [x] WooCommerce Core' ),
-		excludeFromTestingInstructionsIds,
+		excludeFromTestingInstructionsPrIds,
 	);
 	const corePrIds = corePrs.map( ( pr ) => pr.number );
 	const featurePluginPrs = getPrsMatchingText(
 		prList,
 		( body ) => body.includes( '* [x] Feature plugin' ),
-		[...excludeFromTestingInstructionsIds, corePrIds, ...experimentalPrIds ],
+		[...excludeFromTestingInstructionsPrIds, ...corePrIds, ...experimentalPrIds ],
 	);
-
+	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
+	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(
@@ -71,7 +74,7 @@ ${ featurePluginTestingInstructions }` : '';
 	return `## Testing notes and ZIP for release ${ milestoneTitle }
 
 Zip file for testing: [insert link to built zip here]
-${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }
+${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }${ unaccountedForPrMessage };
 `;
 };
 

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -116,7 +116,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		return error;
 	}
 	debug( JSON.stringify( changelog ) );
-	if ( ! pr.number in changelog ) {
+	if ( ! changelog.hasOwnProperty( pr.number ) && changelog[ pr.number ] ) {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -115,6 +115,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		debug( error );
 		return error;
 	}
+	debug( JSON.stringify( changelog ) );
 	if ( ! pr.number in changelog ) {
 		return error;
 	}

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -71,8 +71,7 @@ ${ featurePluginTestingInstructions }` : '';
 	return `## Testing notes and ZIP for release ${ milestoneTitle }
 
 Zip file for testing: [insert link to built zip here]
-${ formattedCoreTestingInstructions }
-${ formattedFeaturePluginTestingInstructions }
+${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }
 `;
 };
 

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -22,6 +22,9 @@ const debug = require( '../debug' );
  */
 export const getTestingInstructions = async ( context, octokit, milestoneTitle, config ) => {
 	const prList = await fetchAllPullRequests( context, octokit, milestoneTitle);
+
+	// We need to keep track of all PR ids so we can check which ones slated for this release have been accounted for
+	// in the testing instructions.
 	const allPrIds = prList.map( ( pr ) => pr.number );
 
 	const doNotIncludeInTestingInstructionsPrs = getPrsMatchingText(
@@ -43,15 +46,26 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 		excludeFromTestingInstructionsPrIds,
 	);
 	const corePrIds = corePrs.map( ( pr ) => pr.number );
+
+	// Here, we're only including PRs that are marked as Feature Plugin and nothing else, this is to handle the case
+	// where an IC might inadvertently mark a PR as both WooCommerce core and Feature plugin.
 	const featurePluginPrs = getPrsMatchingText(
 		prList,
 		( body ) => body.includes( '* [x] Feature plugin' ),
 		[...excludeFromTestingInstructionsPrIds, ...corePrIds, ...experimentalPrIds ],
 	);
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
+
+	// Now we check the IDs of all PRs that have been categorised, and make sure none have been missed. We check against
+	// allPrIds. If some have been missed, an error gets included in the testing instructions and the release lead
+	// can check manually.
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
 	const htmlUrl = context.payload.repository.html_url;
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pull/${ id })` );
+	const prsWithNoTestingCategory = allPrIds.filter(
+		( id ) => ! allAssignedPrIds.includes( id ) )
+		.map(
+			( id ) => `[#${ id }](${ htmlUrl }/pull/${ id })`
+		);
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
@@ -88,7 +102,12 @@ ${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstruction
  */
 const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	const { body: prBody } = pr;
+
+	// Remove all comments from the PR body so they don't get in the way.
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
+
+	// If this section isn't in the PR, then we'll error out and show that in the testing instructions instead. Release
+	// lead will need to manually check in this case.
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
 	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pull/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -51,7 +51,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
 	const htmlUrl = context.payload.repository.html_url;
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }]( ${ htmlUrl }/pulls/${ id })` );
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pulls/${ id })` );
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -120,6 +120,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}
+	debug( `PR ${ pr.number } was found in changelog ${ JSON.stringify( changelog ) }. Extracting changelog then!` );
 	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;
 }
 

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -116,7 +116,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		return error;
 	}
 	debug( JSON.stringify( changelog ) );
-	if ( ! changelog.hasOwnProperty( pr.number ) && changelog[ pr.number ] ) {
+	if ( ! pr.number.toString() in changelog ) {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -116,7 +116,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		return error;
 	}
 	debug( JSON.stringify( changelog ) );
-	if ( ! pr.number.toString() in changelog ) {
+	if ( ! pr.number in changelog || ! changelog[ pr.number ] ) {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -117,6 +117,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	}
 	debug( JSON.stringify( changelog ) );
 	if ( ! pr.number in changelog ) {
+		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}
 	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -51,7 +51,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
 	const htmlUrl = context.payload.repository.html_url;
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pulls/${ id })` );
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }](${ htmlUrl }/pull/${ id })` );
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
@@ -91,7 +91,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pulls/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
+	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pull/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -69,7 +69,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
-		[ ...corePrs, ...featurePluginPrs ].map(
+		[ ...corePrs, ...featurePluginPrs, ...experimentalPrIds ].map(
 			( pr ) => ( [ pr.number, getChangelogEntry( pr ) ] )
 		)
 	);

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -51,7 +51,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
 	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(' , #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n#') } ` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -50,8 +50,9 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	);
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n\n#') }` : '';
+	const htmlUrl = context.payload.repository.html_url;
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) ).map( ( id ) => `[#${ id }]( ${ htmlUrl }/pulls/${ id })` );
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs ${ prsWithNoTestingCategory.join(', ') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(
@@ -59,7 +60,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 		)
 	);
 
-	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds );
+	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds, context );
 	const coreTestingInstructions = corePrs.map( prTestingInstructionsMapFunc ).join( '' );
 	const featurePluginTestingInstructions = featurePluginPrs.map( prTestingInstructionsMapFunc ).join( '' );
 	const formattedCoreTestingInstructions = corePrs.length > 0 ?  `\n## Feature Plugin and package inclusion in WooCommerce
@@ -82,14 +83,15 @@ ${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstruction
  * Gets the testing instructions section of a PR.
  * @param pr {PullRequest} The PR to get the instructions from.
  * @param changelog {object} Object keyed by PR ID and whose values are the changelog entries with links to the PR.
+ * @param htmlUrl {string} The HTML URL of the repository so we can hyperlink the PR numbers.
  * @return {string}
  */
-const extractTestingInstructions = ( pr, changelog ) => {
+const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	const { body: prBody } = pr;
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `### ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
+	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pulls/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -92,7 +92,7 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
 	const error = `### ⚠️ PR [#${ pr.number }'s](${ htmlUrl }/pull/${ pr.number }) testing instructions could not be parsed. Please check it!\n\n`
-	if ( ! matches || ! matches[ 1 ] ) {
+	if ( ! matches || ! matches[ 1 ] || ! matches[1].trim() ) {
 		debug( error );
 		return error;
 	}

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -120,7 +120,6 @@ const extractTestingInstructions = ( pr, changelog, htmlUrl ) => {
 		debug( `PR ${ pr.number } not found in changelog. Skipping extracting testing instructions.` );
 		return error;
 	}
-	debug( `PR ${ pr.number } was found in changelog ${ JSON.stringify( changelog ) }. Extracting changelog then!` );
 	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;
 }
 

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -1,0 +1,110 @@
+/**
+ * Internal dependencies
+ */
+import { getEntry } from './changelog';
+
+const {fetchAllPullRequests} = require('./changelog');
+const debug = require( '../debug' );
+
+/**
+ * @typedef {import('@octokit/types').PullsGetResponseData} PullRequest
+ * @typedef {import('../typedefs').GitHub} GitHub
+ * @typedef {import('../typedefs').ReleaseConfig} ReleaseConfig
+ */
+
+/**
+ * Gets the testing instructions as a string for inclusion in the PR.
+ * @param {GitHubContext} context
+ * @param {GitHub} octokit
+ * @param {string} milestoneTitle The name of the milestone.
+ * @param {ReleaseConfig} config The release configuration.
+ * @return {Promise<string>} The testing instructions in a string.
+ */
+export const getTestingInstructions = async ( context, octokit, milestoneTitle, config ) => {
+	const prList = await fetchAllPullRequests( context, octokit, milestoneTitle);
+
+	const doNotIncludeInTestingInstructionsPrs = getPrsMatchingText(
+		prList,
+		( body ) => body.includes( '* [x] Do not include in the Testing Notes' ),
+	);
+	const excludeFromTestingInstructionsIds = doNotIncludeInTestingInstructionsPrs.map( (pr) => pr.number );
+
+	const experimentalPrs = getPrsMatchingText(
+		prList,
+		( body ) => body.includes( '* [x] Experimental' ),
+		excludeFromTestingInstructionsIds,
+	);
+	const experimentalPrIds = experimentalPrs.map( ( pr ) => pr.number );
+
+
+	const corePrs = getPrsMatchingText(
+		prList,
+		( body ) => body.includes( '* [x] WooCommerce Core' ),
+		excludeFromTestingInstructionsIds,
+	);
+	const corePrIds = corePrs.map( ( pr ) => pr.number );
+	const featurePluginPrs = getPrsMatchingText(
+		prList,
+		( body ) => body.includes( '* [x] Feature plugin' ),
+		[...excludeFromTestingInstructionsIds, corePrIds, ...experimentalPrIds ],
+	);
+
+	const getChangelogEntry = getEntry( config );
+	const changelogWithPrIds = Object.fromEntries(
+		[ ...corePrs, ...featurePluginPrs ].map(
+			( pr ) => ( [ pr.number, getChangelogEntry( pr ) ] )
+		)
+	);
+
+	const prTestingInstructionsMapFunc = ( pr ) => extractTestingInstructions( pr, changelogWithPrIds );
+	const coreTestingInstructions = corePrs.map( prTestingInstructionsMapFunc ).join( '' );
+	const featurePluginTestingInstructions = featurePluginPrs.map( prTestingInstructionsMapFunc ).join( '' );
+	const formattedCoreTestingInstructions = corePrs.length > 0 ?  `\n## Feature Plugin and package inclusion in WooCommerce
+
+${ coreTestingInstructions }` : '';
+
+	const formattedFeaturePluginTestingInstructions = featurePluginPrs.length > 0 ?  `## Feature Plugin
+
+${ featurePluginTestingInstructions }` : '';
+
+
+	return `## Testing notes and ZIP for release ${ milestoneTitle }
+
+Zip file for testing: [insert link to built zip here]
+${ formattedCoreTestingInstructions }
+${ formattedFeaturePluginTestingInstructions }
+`;
+};
+
+/**
+ * Gets the testing instructions section of a PR.
+ * @param pr {PullRequest} The PR to get the instructions from.
+ * @param changelog {object} Object keyed by PR ID and whose values are the changelog entries with links to the PR.
+ * @return {string}
+ */
+const extractTestingInstructions = ( pr, changelog ) => {
+	const { body: prBody } = pr;
+	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
+	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
+	const matches = prBodyWithoutComments.match( regex );
+	const error = `⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!`
+	if ( ! matches || ! matches[ 1 ] ) {
+		debug( error );
+		return error;
+	}
+	if ( ! pr.number in changelog ) {
+		return error;
+	}
+	return `### ${ changelog[ pr.number ].substr( 2 ) }\n\n${ matches[1].trim() }\n\n`;
+}
+
+/**
+ * Gets PRs for which the filter returns true.
+ * @param prList {PullRequest[]}
+ * @param filter {( string ) => boolean} A function to run against the
+ * @param excludePrIds {number[]} A list of pr numbers to exclude.
+ * @return {PullRequest[]} Returns a list of pull requests that satisfy the filter.
+ */
+const getPrsMatchingText = ( prList, filter, excludePrIds = [] ) => {
+	return prList.filter( pr => ! excludePrIds.includes( pr.number ) && filter( pr.body ) );
+}

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -89,7 +89,7 @@ const extractTestingInstructions = ( pr, changelog ) => {
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!`
+	const error = `# ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -49,9 +49,9 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 		[...excludeFromTestingInstructionsPrIds, ...corePrIds, ...experimentalPrIds ],
 	);
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
-	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
-	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n#') } ` : '';
+	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, ...experimentalPrIds, ...excludeFromTestingInstructionsPrIds ];
+	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! allAssignedPrIds.includes( id ) );
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - The following PRs do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.\n#${ prsWithNoTestingCategory.join('\n\n#') }` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(
@@ -74,7 +74,7 @@ ${ featurePluginTestingInstructions }` : '';
 	return `## Testing notes and ZIP for release ${ milestoneTitle }
 
 Zip file for testing: [insert link to built zip here]
-${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }${ unaccountedForPrMessage };
+${ formattedCoreTestingInstructions }${ formattedFeaturePluginTestingInstructions }${ unaccountedForPrMessage }
 `;
 };
 

--- a/lib/utils/testing-instructions.js
+++ b/lib/utils/testing-instructions.js
@@ -51,7 +51,7 @@ export const getTestingInstructions = async ( context, octokit, milestoneTitle, 
 	const featurePluginPrIds = featurePluginPrs.map( ( pr ) => pr.number );
 	const allAssignedPrIds = [ ...corePrIds, ...featurePluginPrIds, experimentalPrIds, excludeFromTestingInstructionsPrIds ];
 	const prsWithNoTestingCategory = allPrIds.filter( ( id ) => ! [ ...corePrIds, ...experimentalPrIds, ...featurePluginPrIds ].includes( id ) );
-	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `# ⚠️ Warning - PRs could not be categorised!\n\nPRs #${ prsWithNoTestingCategory.join(', #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
+	const unaccountedForPrMessage = prsWithNoTestingCategory.length > 0 ? `### ⚠️ Warning - PRs #${ prsWithNoTestingCategory.join(' , #') } do not have any testing category assigned. Please check the PR body to verify it should/should not be included in the testing instructions.` : '';
 	const getChangelogEntry = getEntry( config );
 	const changelogWithPrIds = Object.fromEntries(
 		[ ...corePrs, ...featurePluginPrs ].map(
@@ -89,7 +89,7 @@ const extractTestingInstructions = ( pr, changelog ) => {
 	const prBodyWithoutComments = prBody.replace( /(<!--.*?-->)|(<!--[\S\s]+?-->)|(<!--[\S\s]*?$)/g, '' );
 	const regex = /### User Facing Testing(.*)\* \[ ] Do not include in the testing notes/mis;
 	const matches = prBodyWithoutComments.match( regex );
-	const error = `# ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
+	const error = `### ⚠️ PR [#${ pr.number }](${ pr.url }) testing instructions could not be parsed. Please check it!\n\n`
 	if ( ! matches || ! matches[ 1 ] ) {
 		debug( error );
 		return error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6564,6 +6564,26 @@
           "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
           "dev": true
         },
+        "puppeteer": {
+          "version": "npm:puppeteer-core@5.5.0",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+          "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "devtools-protocol": "0.0.818844",
+            "extract-zip": "^2.0.0",
+            "https-proxy-agent": "^4.0.0",
+            "node-fetch": "^2.6.1",
+            "pkg-dir": "^4.2.0",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^3.0.2",
+            "tar-fs": "^2.0.0",
+            "unbzip2-stream": "^1.3.3",
+            "ws": "^7.2.3"
+          }
+        },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -15048,9 +15068,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "npm:wp-prettier@2.0.5",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-      "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+      "version": "npm:wp-prettier@2.6.2",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+      "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -15222,26 +15242,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "puppeteer": {
-      "version": "npm:puppeteer-core@5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
-      }
     },
     "q": {
       "version": "1.5.1",


### PR DESCRIPTION
This PR adds more functionality to the release PR automation, specifically it extracts testing instructions from the PRs included in the release and adds them to `docs/testing/releases/{version}.md` as well as updating the index file to include a link to the new doc.

A rundown of what has changed:
- Exported ` fetchAllPullRequests` and `getEntry` from `utils/changelog` - this is necessary so we can extract changelog entries from PRs.
- Added a file in `utils` called `testing-instructions.js` - this exports a single function: `getTestingInstructions` which returns the testing instructions for this release as a string.
- Updated `lib/automations/release/branch-create-handler.js` to handle adding the instructions as part of the release PR creation.

### Testing instructions
To test this, you will need to:
- **Fork** the `woocommerce-gutenberg-products-block` and then unfork it (Go to this url: https://support.github.com/contact?tags=rr-forks and type `unfork` into the subject line. Follow the steps from the virtual assistant and wait 5-10 mins for the request to be actioned).
- Enable issues on your new unforked repository (go to `Settings > General > Features > Issues`)
- Activate GH actions
- Give read and write permissions to the workflows: Settings > Actions > General > Workflow permissions
- Allow GH actions to create PRs: Settings > Actions > General
- Create a milestone (I used 9.9.0, but pick whatever you like)
- Clone your repository locally.
- Create a PR on your repository, in this PR you should change the following file: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/.github/workflows/release-pull-request.yml#L27
- Change the highlighted line to read: `uses: opr/automations@add/testing-instructions-automation` **note this is a different tag to the other PR so ensure this is correct!**
- Merge the PR
- Optionally create multiple PRs.
- Assign them all to the milestone you created earlier.
- Create a new branch, `release/9.9.0` or whatever milestone number you picked.
- Push this branch to the remote.
- Go to your repository on GitHub, you should see a new PR created for the release, and it should have added the testing instructions.

#### Additional testing
- [ ] Make a PR, mark it to be included in WooCommerce Core in the PR body - check it gets added to the correct section in the testing instructions.
- [ ] Make a PR, mark it to be included in Feature Plugin in the PR body - check it gets added to the correct section in the testing instructions.
- [ ] Mark a PR as `skip-changelog` - check it **does** get added to the correct section in the testing instructions.
- [ ] Make a PR, mark it as experimental in the PR body - check it **does not** get added to the testing instructions.

### Even more testing!
This tool even handles adding patch releases to the correct place in the `docs/testing/releases/README.md` file! It is pretty naive though and relies on that file being correctly indented, but with this fancy new tool, we won't have to worry about it!
- [ ] Make a release with an `x.x.1` patch version, verify the link to the testing instructions is placed in the correct place.
- [ ] Make a release with an `x.x.n` patch version (where `n` is greater than 1), verify the link to the testing instructions is placed in the correct place, you will need to ensure there's a previous patch with a minor version of 1 or more already though. I used `7.4.3`.

#### Failure modes 💥
This new automation relies on our PRs being formatted properly, if people don't include the correct markdown for the testing instructions, then the text will not be extracted properly or it will not be categorised properly.
- Do not add any testing instructions, do not tick any boxes, check that the testing instructions contain an error for that PR.
- Remove the `### User Facing Testing` header from your PR - check the testing instructions contain an error for that PR.