### PR TITLE
Add minimum required WC & WP versions in various files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -455,8 +455,22 @@ const {
  */
 const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 	const regex = /== Changelog ==\n/;
-	return contents.replace( regex, `== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`);
+	return contents.replace(
+		regex,
+		`== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`
+	);
 }
+
+const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
+	const versionList = latestWPVersion.split( '.' );
+	const version = `${ versionList[ 0 ] }.${ versionList[ 1 ] }`;
+	const regexRequiresAtLeast = /Requires at least:.*/;
+	const regexTestedUpTo = /Tested up to:.*/;
+	return contents
+		.replace( regexRequiresAtLeast, `Requires at least: ${ version }` )
+		.replace( regexTestedUpTo, `Tested up to: ${ version }` );
+};
+
 /**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
@@ -601,13 +615,36 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
+	const wpTags = await octokit.request(
+		'GET /repos/WordPress/WordPress/tags',
+		{
+			owner: 'WordPress',
+			repo: 'WordPress',
+		}
+	);
+
 	// Content comes from GH API in base64 so convert it to utf-8 string.
 	const readmeBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
 	const readmeContents = readmeBuffer.toString( 'utf-8' );
 
+	const updatedReadmeChangeLog = insertNewChangelogEntry(
+		readmeContents,
+		// changelog,
+		'## My Change log!!',
+		releaseVersion
+	);
+
+	const updatedReadmeMinRequiredVersion = updateMinRequiredVersionsReadme(
+		updatedReadmeChangeLog,
+		wpTags.data[ 0 ].name
+	);
+
 	// Need to convert back to base64 to write to the repo.
-	const updatedReadmeContentBuffer = new Buffer.from( insertNewChangelogEntry( readmeContents, changelog, releaseVersion ), 'utf-8' );
-	const updatedReadmeContent = updatedReadmeContentBuffer.toString( 'base64' );
+	const updatedReadmeBuffer = new Buffer.from(
+		updatedReadmeMinRequiredVersion,
+		'utf-8'
+	);
+	const updatedReadmeContent = updatedReadmeBuffer.toString( 'base64' );
 
 	const readmeSha = readmeResponse.data.sha;
 	const updatedReadmeCommit = await octokit.repos.createOrUpdateFileContents({
@@ -623,6 +660,58 @@ const branchHandler = async ( context, octokit, config ) => {
 		debug( `releaseAutomation: Automatic update of readme failed.` );
 		return;
 	}
+
+	// const wooBlockPHPResponse = await octokit.repos.getContent( {
+	// 	...context.repo,
+	// 	path: 'woocommerce-gutenberg-products-block.php',
+	// } );
+
+	// if ( ! wooBlockPHPResponse ) {
+	// 	debug(
+	// 		`releaseAutomation: Could not read woocommerce-gutenberg-products-block.php file from repository.`
+	// 	);
+	// 	return;
+	// }
+
+	// // Content comes from GH API in base64 so convert it to utf-8 string.
+	// const wooBlockPHPBuffer = new Buffer.from(
+	// 	wooBlockPHPResponse.data.content,
+	// 	'base64'
+	// );
+	// const wooBlockPHPContents = wooBlockPHPBuffer.toString( 'utf-8' );
+
+	// // Need to convert back to base64 to write to the repo.
+	// const updatedWooBlockPHPContentBuffer = new Buffer.from(
+	// 	insertNewChangelogEntry(
+	// 		wooBlockPHPContents,
+	// 		changelog,
+	// 		releaseVersion
+	// 	),
+	// 	'utf-8'
+	// );
+	// const updatedWooBlockPHPContent = updatedWooBlockPHPContentBuffer.toString(
+	// 	'base64'
+	// );
+
+	// const wooBlockPHPSha = wooBlockPHPResponse.data.sha;
+	// const updatedWooBlockPHPCommit = await octokit.repos.createOrUpdateFileContents(
+	// 	{
+	// 		...context.repo,
+	// 		message:
+	// 			'Update minimum required wc & wp versions in woocommerce-gutenberg-products-block.php',
+	// 		path: 'woocommerce-gutenberg-products-block.php',
+	// 		content: updatedWooBlockPHPContent,
+	// 		sha: wooBlockPHPSha,
+	// 		branch: context.payload.ref,
+	// 	}
+	// );
+
+	// if ( ! updatedWooBlockPHPCommit ) {
+	// 	debug(
+	// 		`releaseAutomation: Automatic update of woocommerce-gutenberg-products-block.php failed.`
+	// 	);
+	// 	return;
+	// }
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/dist/index.js
+++ b/dist/index.js
@@ -461,6 +461,13 @@ const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 	);
 }
 
+/**
+ * Inserts the new changelog entry into the readme file contents
+ *
+ * @param {string} contents The contents of the readme.txt file
+ * @param {string} latestWPVersion The latest version of WordPress.
+ * @return {string} The new content of the readme.txt file containing the updated WP version.
+ */
 const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 	const versionList = latestWPVersion.split( '.' );
 	const version = `${ versionList[ 0 ] }.${ versionList[ 1 ] }`;
@@ -471,6 +478,14 @@ const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 		.replace( regexTestedUpTo, `Tested up to: ${ version }` );
 };
 
+/**
+ * Inserts the new changelog entry into the readme file contents
+ *
+ * @param {string} contents The contents of the "Woo Block PHP" file
+ * @param {string} latestWPVersion The latest version of WordPress.
+ * @param {string} latestWCVersion The latest version of WooCommerce.
+ * @return {string} The new content of the file containing the updated WP & WC versions.
+ */
 const updateMinRequiredVersionsWooBlockPHP = (
 	contents,
 	latestWPVersion,
@@ -491,12 +506,9 @@ const updateMinRequiredVersionsWooBlockPHP = (
 		.replace( regexRequiresAtLeast, `* Requires at least: ${ wpVersion }` )
 		.replace(
 			regexWCRequiresAtLeast,
-			`* WC requires at least: ${ wcVersion }`
+			`* WC requires at least: ${ previousWCVersion }`
 		)
-		.replace(
-			regexWCTestedUpTo,
-			`* WC tested up to: ${ previousWCVersion }`
-		);
+		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` );
 };
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -512,7 +512,10 @@ const updateMinRequiredVersionsWooBlockPHP = (
 			`* WC requires at least: ${ previousWCVersion }`
 		)
 		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` )
-		.replace( regexMinWPVersion, `\$minimum_wp_version = ${ wpVersion };` );
+		.replace(
+			regexMinWPVersion,
+			`\$minimum_wp_version = '${ wpVersion }';`
+		);
 };
 
 /**
@@ -670,7 +673,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		);
 	};
 
-	const updatedReadmeCommit = updateFile(
+	const updatedReadmeCommit = await updateFile(
 		context,
 		octokit,
 		readmePath,
@@ -690,7 +693,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			wcLatestReleaseVersion
 		);
 
-	const updatedWooBlockPHPCommit = updateFile(
+	const updatedWooBlockPHPCommit = await updateFile(
 		context,
 		octokit,
 		wooBlockPHPPath,

--- a/dist/index.js
+++ b/dist/index.js
@@ -629,8 +629,7 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const updatedReadmeChangeLog = insertNewChangelogEntry(
 		readmeContents,
-		// changelog,
-		'## My Change log!!',
+		changelog,
 		releaseVersion
 	);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -529,10 +529,15 @@ const updateMinWPVersionPHPCS = ( contents, latestWPVersion ) => {
 	const wpVersionList = latestWPVersion.split( '.' );
 	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
 	const regexRequiresAtLeast = /<.*minimum_supported_wp_version.*>/;
-	return contents.replace(
+
+	const result = contents.replace(
 		regexRequiresAtLeast,
 		`<config name="minimum_supported_wp_version" value="${ wpVersion }" />`
 	);
+
+	debug( `result: ${ result }` );
+
+	return result;
 };
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -706,7 +706,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const {
 		wpLatestReleaseVersion,
 		wcLatestReleaseVersion,
-	} = getWPAndWCReleaseVersions( octokit );
+	} = await getWPAndWCReleaseVersions( octokit );
 
 	const readmePath = 'readme.txt';
 	const readmeUpdateFileMessage = `Update changelog in ${ readmePath }`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -512,6 +512,62 @@ const updateMinRequiredVersionsWooBlockPHP = (
 };
 
 /**
+ * Callback test.
+ *
+ * @callback updateContent
+ * @param {string} content
+ */
+/**
+ * @param {GitHubContext} context
+ * @param {GitHub} octokit
+ * @param {string} path The path of the file to update
+ * @param {string} message The message for the reason of the file update
+ * @param {updateContent} updateContent callback to update the content of the file
+ */
+const updateFile = async ( context, octokit, path, message, updateContent ) => {
+	const contentResponse = await octokit.repos.getContent( {
+		...context.repo,
+		path,
+	} );
+
+	if ( ! contentResponse ) {
+		debug(
+			`releaseAutomation: Could not read ${ path } file from repository.`
+		);
+		return;
+	}
+
+	// Content comes from GH API in base64 so convert it to utf-8 string.
+	const contentBuffer = new Buffer.from(
+		contentResponse.data.content,
+		'base64'
+	);
+	const contents = contentBuffer.toString( 'utf-8' );
+
+	// Need to convert back to base64 to write to the repo.
+	const updatedContentBuffer = new Buffer.from(
+		updateContent( contents ),
+		'utf-8'
+	);
+	const updatedContent = updatedContentBuffer.toString( 'base64' );
+
+	const fileSha = contentResponse.data.sha;
+	const updatedCommit = await octokit.repos.createOrUpdateFileContents( {
+		...context.repo,
+		message,
+		path,
+		content: updatedContent,
+		sha: fileSha,
+		branch: context.payload.ref,
+	} );
+
+	if ( ! updatedCommit ) {
+		debug( `releaseAutomation: Automatic update of ${ path } failed.` );
+		return;
+	}
+};
+
+/**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
  * @param {ReleaseConfig} config
@@ -645,16 +701,6 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
-	const readmeResponse = await octokit.repos.getContent({
-		...context.repo,
-		path: 'readme.txt',
-	});
-
-	if ( ! readmeResponse ) {
-		debug( `releaseAutomation: Could not read readme.txt file from repository.` );
-		return;
-	}
-
 	const wpTags = await octokit.request(
 		'GET /repos/WordPress/WordPress/tags',
 		{
@@ -664,42 +710,29 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 	const wpLatestReleaseVersion = wpTags.data[ 0 ].name;
 
-	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const readmeBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
-	const readmeContents = readmeBuffer.toString( 'utf-8' );
+	const readmePath = 'readme.txt';
+	const readmeUpdateFileMessage = `Update changelog in ${ readmePath }`;
 
-	const updatedReadmeChangeLog = insertNewChangelogEntry(
-		readmeContents,
-		changelog,
-		releaseVersion
+	const updateReadmeContent = ( content ) => {
+		const updatedReadmeChangeLog = insertNewChangelogEntry(
+			content,
+			changelog,
+			releaseVersion
+		);
+
+		return updateMinRequiredVersionsReadme(
+			updatedReadmeChangeLog,
+			wpLatestReleaseVersion
+		);
+	};
+
+	updateFile(
+		context,
+		octokit,
+		readmePath,
+		readmeUpdateFileMessage,
+		updateReadmeContent
 	);
-
-	const updatedReadmeMinRequiredVersion = updateMinRequiredVersionsReadme(
-		updatedReadmeChangeLog,
-		wpLatestReleaseVersion
-	);
-
-	// Need to convert back to base64 to write to the repo.
-	const updatedReadmeBuffer = new Buffer.from(
-		updatedReadmeMinRequiredVersion,
-		'utf-8'
-	);
-	const updatedReadmeContent = updatedReadmeBuffer.toString( 'base64' );
-
-	const readmeSha = readmeResponse.data.sha;
-	const updatedReadmeCommit = await octokit.repos.createOrUpdateFileContents({
-		...context.repo,
-		message: 'Update changelog in readme.txt',
-		path: 'readme.txt',
-		content: updatedReadmeContent,
-		sha: readmeSha,
-		branch: context.payload.ref,
-	});
-
-	if ( ! updatedReadmeCommit ) {
-		debug( `releaseAutomation: Automatic update of readme failed.` );
-		return;
-	}
 
 	// Get WooCommerce data
 	const wcLatestRelease = await octokit.request(
@@ -712,57 +745,23 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const wcLatestReleaseVersion = wcLatestRelease.data.name;
 
-	const wooBlockPHPResponse = await octokit.repos.getContent( {
-		...context.repo,
-		path: 'woocommerce-gutenberg-products-block.php',
-	} );
+	const wooBlockPHPPath = 'woocommerce-gutenberg-products-block.php';
+	const wooBlockPHPUpdateFileMessage = `Update minimum required wc & wp versions in ${ wooBlockPHPPath }`;
 
-	if ( ! wooBlockPHPResponse ) {
-		debug(
-			`releaseAutomation: Could not read woocommerce-gutenberg-products-block.php file from repository.`
-		);
-		return;
-	}
-
-	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const wooBlockPHPBuffer = new Buffer.from(
-		wooBlockPHPResponse.data.content,
-		'base64'
-	);
-	const wooBlockPHPContents = wooBlockPHPBuffer.toString( 'utf-8' );
-
-	// Need to convert back to base64 to write to the repo.
-	const updatedWooBlockPHPContentBuffer = new Buffer.from(
+	const updateWooBlockPHPContent = ( content ) =>
 		updateMinRequiredVersionsWooBlockPHP(
-			wooBlockPHPContents,
+			content,
 			wpLatestReleaseVersion,
 			wcLatestReleaseVersion
-		),
-		'utf-8'
-	);
-	const updatedWooBlockPHPContent = updatedWooBlockPHPContentBuffer.toString(
-		'base64'
-	);
-
-	const wooBlockPHPSha = wooBlockPHPResponse.data.sha;
-	const updatedWooBlockPHPCommit = await octokit.repos.createOrUpdateFileContents(
-		{
-			...context.repo,
-			message:
-				'Update minimum required wc & wp versions in woocommerce-gutenberg-products-block.php',
-			path: 'woocommerce-gutenberg-products-block.php',
-			content: updatedWooBlockPHPContent,
-			sha: wooBlockPHPSha,
-			branch: context.payload.ref,
-		}
-	);
-
-	if ( ! updatedWooBlockPHPCommit ) {
-		debug(
-			`releaseAutomation: Automatic update of woocommerce-gutenberg-products-block.php failed.`
 		);
-		return;
-	}
+
+	updateFile(
+		context,
+		octokit,
+		wooBlockPHPPath,
+		wooBlockPHPUpdateFileMessage,
+		updateWooBlockPHPContent
+	);
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/dist/index.js
+++ b/dist/index.js
@@ -481,7 +481,7 @@ const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 };
 
 /**
- * Inserts the new changelog entry into the readme file contents
+ * Update WC & WP versions in woocommerce-gutenberg-products-block.php
  *
  * @param {string} contents The contents of the "Woo Block PHP" file
  * @param {string} latestWPVersion The latest version of WordPress.
@@ -516,6 +516,23 @@ const updateMinRequiredVersionsWooBlockPHP = (
 			regexMinWPVersion,
 			`\$minimum_wp_version = '${ wpVersion }';`
 		);
+};
+
+/**
+ * Update the minimum supported WP version in phpcs.xml
+ *
+ * @param {string} contents The contents of phpcs.xml
+ * @param {string} latestWPVersion The latest version of WordPress.
+ * @return {string} The new content of phpcs.xml containing the updated WP version.
+ */
+const updateMinWPVersionPHPCS = ( contents, latestWPVersion ) => {
+	const wpVersionList = latestWPVersion.split( '.' );
+	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
+	const regexRequiresAtLeast = /<.*minimum_supported_wp_version.*>/;
+	return contents.replace(
+		regexRequiresAtLeast,
+		`<config name="minimum_supported_wp_version" value="${ wpVersion }" />`
+	);
 };
 
 /**
@@ -702,6 +719,22 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 
 	if ( ! updatedWooBlockPHPCommit ) return;
+
+	const phpCSPath = 'phpcs.xml';
+	const phpCSUpdateFileMessage = `Update minimum supported wp version in ${ phpCSPath }`;
+
+	const updatePHPCSContent = ( content ) =>
+		updateMinWPVersionPHPCS( content, wpLatestReleaseVersion );
+
+	const updatedPHPCSCommit = await updateFile(
+		context,
+		octokit,
+		phpCSPath,
+		phpCSUpdateFileMessage,
+		updatePHPCSContent
+	);
+
+	if ( ! updatedPHPCSCommit ) return;
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/dist/index.js
+++ b/dist/index.js
@@ -529,15 +529,10 @@ const updateMinWPVersionPHPCS = ( contents, latestWPVersion ) => {
 	const wpVersionList = latestWPVersion.split( '.' );
 	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
 	const regexRequiresAtLeast = /<.*minimum_supported_wp_version.*>/;
-
-	const result = contents.replace(
+	return contents.replace(
 		regexRequiresAtLeast,
 		`<config name="minimum_supported_wp_version" value="${ wpVersion }" />`
 	);
-
-	debug( `result: ${ result }` );
-
-	return result;
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -211,8 +211,7 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const updatedReadmeChangeLog = insertNewChangelogEntry(
 		readmeContents,
-		// changelog,
-		'## My Change log!!',
+		changelog,
 		releaseVersion
 	);
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -73,12 +73,9 @@ const updateMinRequiredVersionsWooBlockPHP = (
 		.replace( regexRequiresAtLeast, `* Requires at least: ${ wpVersion }` )
 		.replace(
 			regexWCRequiresAtLeast,
-			`* WC requires at least: ${ wcVersion }`
+			`* WC requires at least: ${ previousWCVersion }`
 		)
-		.replace(
-			regexWCTestedUpTo,
-			`* WC tested up to: ${ previousWCVersion }`
-		);
+		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` );
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -145,8 +145,9 @@ const updateFile = async ( context, octokit, path, message, updateContent ) => {
 
 	if ( ! updatedCommit ) {
 		debug( `releaseAutomation: Automatic update of ${ path } failed.` );
-		return;
 	}
+
+	return updatedCommit;
 };
 
 /**
@@ -308,13 +309,15 @@ const branchHandler = async ( context, octokit, config ) => {
 		);
 	};
 
-	updateFile(
+	const updatedReadmeCommit = updateFile(
 		context,
 		octokit,
 		readmePath,
 		readmeUpdateFileMessage,
 		updateReadmeContent
 	);
+
+	if ( ! updatedReadmeCommit ) return;
 
 	// Get WooCommerce data
 	const wcLatestRelease = await octokit.request(
@@ -337,13 +340,15 @@ const branchHandler = async ( context, octokit, config ) => {
 			wcLatestReleaseVersion
 		);
 
-	updateFile(
+	const updatedWooBlockPHPCommit = updateFile(
 		context,
 		octokit,
 		wooBlockPHPPath,
 		wooBlockPHPUpdateFileMessage,
 		updateWooBlockPHPContent
 	);
+
+	if ( ! updatedWooBlockPHPCommit ) return;
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -42,6 +42,17 @@ const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 		`== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`
 	);
 }
+
+const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
+	const versionList = latestWPVersion.split( '.' );
+	const version = `${ versionList[ 0 ] }.${ versionList[ 1 ] }`;
+	const regexRequiresAtLeast = /Requires at least:.*/;
+	const regexTestedUpTo = /Tested up to:.*/;
+	return contents
+		.replace( regexRequiresAtLeast, `Requires at least: ${ version }` )
+		.replace( regexTestedUpTo, `Tested up to: ${ version }` );
+};
+
 /**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
@@ -186,13 +197,35 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
+	const wpTags = await octokit.request(
+		'GET /repos/WordPress/WordPress/git/tags',
+		{
+			owner: 'WordPress',
+			repo: 'WordPress',
+		}
+	);
+
 	// Content comes from GH API in base64 so convert it to utf-8 string.
 	const readmeBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
 	const readmeContents = readmeBuffer.toString( 'utf-8' );
 
+	const updatedReadmeChangeLog = insertNewChangelogEntry(
+		readmeContents,
+		changelog,
+		releaseVersion
+	);
+
+	const updatedReadmeMinRequiredVersion = updateMinRequiredVersionsReadme(
+		updatedReadmeChangeLog,
+		wpTags[ 0 ].name
+	);
+
 	// Need to convert back to base64 to write to the repo.
-	const updatedReadmeContentBuffer = new Buffer.from( insertNewChangelogEntry( readmeContents, changelog, releaseVersion ), 'utf-8' );
-	const updatedReadmeContent = updatedReadmeContentBuffer.toString( 'base64' );
+	const updatedReadmeBuffer = new Buffer.from(
+		updatedReadmeMinRequiredVersion,
+		'utf-8'
+	);
+	const updatedReadmeContent = updatedReadmeBuffer.toString( 'base64' );
 
 	const readmeSha = readmeResponse.data.sha;
 	const updatedReadmeCommit = await octokit.repos.createOrUpdateFileContents({
@@ -208,6 +241,58 @@ const branchHandler = async ( context, octokit, config ) => {
 		debug( `releaseAutomation: Automatic update of readme failed.` );
 		return;
 	}
+
+	// const wooBlockPHPResponse = await octokit.repos.getContent( {
+	// 	...context.repo,
+	// 	path: 'woocommerce-gutenberg-products-block.php',
+	// } );
+
+	// if ( ! wooBlockPHPResponse ) {
+	// 	debug(
+	// 		`releaseAutomation: Could not read woocommerce-gutenberg-products-block.php file from repository.`
+	// 	);
+	// 	return;
+	// }
+
+	// // Content comes from GH API in base64 so convert it to utf-8 string.
+	// const wooBlockPHPBuffer = new Buffer.from(
+	// 	wooBlockPHPResponse.data.content,
+	// 	'base64'
+	// );
+	// const wooBlockPHPContents = wooBlockPHPBuffer.toString( 'utf-8' );
+
+	// // Need to convert back to base64 to write to the repo.
+	// const updatedWooBlockPHPContentBuffer = new Buffer.from(
+	// 	insertNewChangelogEntry(
+	// 		wooBlockPHPContents,
+	// 		changelog,
+	// 		releaseVersion
+	// 	),
+	// 	'utf-8'
+	// );
+	// const updatedWooBlockPHPContent = updatedWooBlockPHPContentBuffer.toString(
+	// 	'base64'
+	// );
+
+	// const wooBlockPHPSha = wooBlockPHPResponse.data.sha;
+	// const updatedWooBlockPHPCommit = await octokit.repos.createOrUpdateFileContents(
+	// 	{
+	// 		...context.repo,
+	// 		message:
+	// 			'Update minimum required wc & wp versions in woocommerce-gutenberg-products-block.php',
+	// 		path: 'woocommerce-gutenberg-products-block.php',
+	// 		content: updatedWooBlockPHPContent,
+	// 		sha: wooBlockPHPSha,
+	// 		branch: context.payload.ref,
+	// 	}
+	// );
+
+	// if ( ! updatedWooBlockPHPCommit ) {
+	// 	debug(
+	// 		`releaseAutomation: Automatic update of woocommerce-gutenberg-products-block.php failed.`
+	// 	);
+	// 	return;
+	// }
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -111,15 +111,10 @@ const updateMinWPVersionPHPCS = ( contents, latestWPVersion ) => {
 	const wpVersionList = latestWPVersion.split( '.' );
 	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
 	const regexRequiresAtLeast = /<.*minimum_supported_wp_version.*>/;
-
-	const result = contents.replace(
+	return contents.replace(
 		regexRequiresAtLeast,
 		`<config name="minimum_supported_wp_version" value="${ wpVersion }" />`
 	);
-
-	debug( `result: ${ result }` );
-
-	return result;
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -86,13 +86,15 @@ const updateMinRequiredVersionsWooBlockPHP = (
 	const regexRequiresAtLeast = /\* Requires at least:.*/;
 	const regexWCRequiresAtLeast = /\* WC requires at least:.*/;
 	const regexWCTestedUpTo = /\* WC tested up to:.*/;
+	const regexMinWPVersion = /\$minimum_wp_version =.*/;
 	return contents
 		.replace( regexRequiresAtLeast, `* Requires at least: ${ wpVersion }` )
 		.replace(
 			regexWCRequiresAtLeast,
 			`* WC requires at least: ${ previousWCVersion }`
 		)
-		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` );
+		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` )
+		.replace( regexMinWPVersion, `\$minimum_wp_version = ${ wpVersion };` );
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -94,7 +94,10 @@ const updateMinRequiredVersionsWooBlockPHP = (
 			`* WC requires at least: ${ previousWCVersion }`
 		)
 		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` )
-		.replace( regexMinWPVersion, `\$minimum_wp_version = ${ wpVersion };` );
+		.replace(
+			regexMinWPVersion,
+			`\$minimum_wp_version = '${ wpVersion }';`
+		);
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -11,6 +11,7 @@ const { lineBreak } = require( '../../utils' );
 const debug = require( '../../debug' );
 const {
 	getReleaseVersion,
+	getWPAndWCReleaseVersions,
 	isPatchRelease,
 	getReleaseBranch,
 	duplicateChecker,
@@ -284,14 +285,10 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
-	const wpTags = await octokit.request(
-		'GET /repos/WordPress/WordPress/tags',
-		{
-			owner: 'WordPress',
-			repo: 'WordPress',
-		}
-	);
-	const wpLatestReleaseVersion = wpTags.data[ 0 ].name;
+	const {
+		wpLatestReleaseVersion,
+		wcLatestReleaseVersion,
+	} = getWPAndWCReleaseVersions( octokit );
 
 	const readmePath = 'readme.txt';
 	const readmeUpdateFileMessage = `Update changelog in ${ readmePath }`;
@@ -318,17 +315,6 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 
 	if ( ! updatedReadmeCommit ) return;
-
-	// Get WooCommerce data
-	const wcLatestRelease = await octokit.request(
-		'GET /repos/woocommerce/woocommerce/releases/latest',
-		{
-			owner: 'woocommerce',
-			repo: 'woocommerce',
-		}
-	);
-
-	const wcLatestReleaseVersion = wcLatestRelease.data.name;
 
 	const wooBlockPHPPath = 'woocommerce-gutenberg-products-block.php';
 	const wooBlockPHPUpdateFileMessage = `Update minimum required wc & wp versions in ${ wooBlockPHPPath }`;

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -94,6 +94,62 @@ const updateMinRequiredVersionsWooBlockPHP = (
 };
 
 /**
+ * Callback test.
+ *
+ * @callback updateContent
+ * @param {string} content
+ */
+/**
+ * @param {GitHubContext} context
+ * @param {GitHub} octokit
+ * @param {string} path The path of the file to update
+ * @param {string} message The message for the reason of the file update
+ * @param {updateContent} updateContent callback to update the content of the file
+ */
+const updateFile = async ( context, octokit, path, message, updateContent ) => {
+	const contentResponse = await octokit.repos.getContent( {
+		...context.repo,
+		path,
+	} );
+
+	if ( ! contentResponse ) {
+		debug(
+			`releaseAutomation: Could not read ${ path } file from repository.`
+		);
+		return;
+	}
+
+	// Content comes from GH API in base64 so convert it to utf-8 string.
+	const contentBuffer = new Buffer.from(
+		contentResponse.data.content,
+		'base64'
+	);
+	const contents = contentBuffer.toString( 'utf-8' );
+
+	// Need to convert back to base64 to write to the repo.
+	const updatedContentBuffer = new Buffer.from(
+		updateContent( contents ),
+		'utf-8'
+	);
+	const updatedContent = updatedContentBuffer.toString( 'base64' );
+
+	const fileSha = contentResponse.data.sha;
+	const updatedCommit = await octokit.repos.createOrUpdateFileContents( {
+		...context.repo,
+		message,
+		path,
+		content: updatedContent,
+		sha: fileSha,
+		branch: context.payload.ref,
+	} );
+
+	if ( ! updatedCommit ) {
+		debug( `releaseAutomation: Automatic update of ${ path } failed.` );
+		return;
+	}
+};
+
+/**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
  * @param {ReleaseConfig} config
@@ -227,16 +283,6 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
-	const readmeResponse = await octokit.repos.getContent({
-		...context.repo,
-		path: 'readme.txt',
-	});
-
-	if ( ! readmeResponse ) {
-		debug( `releaseAutomation: Could not read readme.txt file from repository.` );
-		return;
-	}
-
 	const wpTags = await octokit.request(
 		'GET /repos/WordPress/WordPress/tags',
 		{
@@ -246,42 +292,29 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 	const wpLatestReleaseVersion = wpTags.data[ 0 ].name;
 
-	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const readmeBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
-	const readmeContents = readmeBuffer.toString( 'utf-8' );
+	const readmePath = 'readme.txt';
+	const readmeUpdateFileMessage = `Update changelog in ${ readmePath }`;
 
-	const updatedReadmeChangeLog = insertNewChangelogEntry(
-		readmeContents,
-		changelog,
-		releaseVersion
+	const updateReadmeContent = ( content ) => {
+		const updatedReadmeChangeLog = insertNewChangelogEntry(
+			content,
+			changelog,
+			releaseVersion
+		);
+
+		return updateMinRequiredVersionsReadme(
+			updatedReadmeChangeLog,
+			wpLatestReleaseVersion
+		);
+	};
+
+	updateFile(
+		context,
+		octokit,
+		readmePath,
+		readmeUpdateFileMessage,
+		updateReadmeContent
 	);
-
-	const updatedReadmeMinRequiredVersion = updateMinRequiredVersionsReadme(
-		updatedReadmeChangeLog,
-		wpLatestReleaseVersion
-	);
-
-	// Need to convert back to base64 to write to the repo.
-	const updatedReadmeBuffer = new Buffer.from(
-		updatedReadmeMinRequiredVersion,
-		'utf-8'
-	);
-	const updatedReadmeContent = updatedReadmeBuffer.toString( 'base64' );
-
-	const readmeSha = readmeResponse.data.sha;
-	const updatedReadmeCommit = await octokit.repos.createOrUpdateFileContents({
-		...context.repo,
-		message: 'Update changelog in readme.txt',
-		path: 'readme.txt',
-		content: updatedReadmeContent,
-		sha: readmeSha,
-		branch: context.payload.ref,
-	});
-
-	if ( ! updatedReadmeCommit ) {
-		debug( `releaseAutomation: Automatic update of readme failed.` );
-		return;
-	}
 
 	// Get WooCommerce data
 	const wcLatestRelease = await octokit.request(
@@ -294,57 +327,23 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const wcLatestReleaseVersion = wcLatestRelease.data.name;
 
-	const wooBlockPHPResponse = await octokit.repos.getContent( {
-		...context.repo,
-		path: 'woocommerce-gutenberg-products-block.php',
-	} );
+	const wooBlockPHPPath = 'woocommerce-gutenberg-products-block.php';
+	const wooBlockPHPUpdateFileMessage = `Update minimum required wc & wp versions in ${ wooBlockPHPPath }`;
 
-	if ( ! wooBlockPHPResponse ) {
-		debug(
-			`releaseAutomation: Could not read woocommerce-gutenberg-products-block.php file from repository.`
-		);
-		return;
-	}
-
-	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const wooBlockPHPBuffer = new Buffer.from(
-		wooBlockPHPResponse.data.content,
-		'base64'
-	);
-	const wooBlockPHPContents = wooBlockPHPBuffer.toString( 'utf-8' );
-
-	// Need to convert back to base64 to write to the repo.
-	const updatedWooBlockPHPContentBuffer = new Buffer.from(
+	const updateWooBlockPHPContent = ( content ) =>
 		updateMinRequiredVersionsWooBlockPHP(
-			wooBlockPHPContents,
+			content,
 			wpLatestReleaseVersion,
 			wcLatestReleaseVersion
-		),
-		'utf-8'
-	);
-	const updatedWooBlockPHPContent = updatedWooBlockPHPContentBuffer.toString(
-		'base64'
-	);
-
-	const wooBlockPHPSha = wooBlockPHPResponse.data.sha;
-	const updatedWooBlockPHPCommit = await octokit.repos.createOrUpdateFileContents(
-		{
-			...context.repo,
-			message:
-				'Update minimum required wc & wp versions in woocommerce-gutenberg-products-block.php',
-			path: 'woocommerce-gutenberg-products-block.php',
-			content: updatedWooBlockPHPContent,
-			sha: wooBlockPHPSha,
-			branch: context.payload.ref,
-		}
-	);
-
-	if ( ! updatedWooBlockPHPCommit ) {
-		debug(
-			`releaseAutomation: Automatic update of woocommerce-gutenberg-products-block.php failed.`
 		);
-		return;
-	}
+
+	updateFile(
+		context,
+		octokit,
+		wooBlockPHPPath,
+		wooBlockPHPUpdateFileMessage,
+		updateWooBlockPHPContent
+	);
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -43,6 +43,13 @@ const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 	);
 }
 
+/**
+ * Inserts the new changelog entry into the readme file contents
+ *
+ * @param {string} contents The contents of the readme.txt file
+ * @param {string} latestWPVersion The latest version of WordPress.
+ * @return {string} The new content of the readme.txt file containing the updated WP version.
+ */
 const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 	const versionList = latestWPVersion.split( '.' );
 	const version = `${ versionList[ 0 ] }.${ versionList[ 1 ] }`;
@@ -53,6 +60,14 @@ const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 		.replace( regexTestedUpTo, `Tested up to: ${ version }` );
 };
 
+/**
+ * Inserts the new changelog entry into the readme file contents
+ *
+ * @param {string} contents The contents of the "Woo Block PHP" file
+ * @param {string} latestWPVersion The latest version of WordPress.
+ * @param {string} latestWCVersion The latest version of WooCommerce.
+ * @return {string} The new content of the file containing the updated WP & WC versions.
+ */
 const updateMinRequiredVersionsWooBlockPHP = (
 	contents,
 	latestWPVersion,

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -63,7 +63,7 @@ const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 };
 
 /**
- * Inserts the new changelog entry into the readme file contents
+ * Update WC & WP versions in woocommerce-gutenberg-products-block.php
  *
  * @param {string} contents The contents of the "Woo Block PHP" file
  * @param {string} latestWPVersion The latest version of WordPress.
@@ -98,6 +98,23 @@ const updateMinRequiredVersionsWooBlockPHP = (
 			regexMinWPVersion,
 			`\$minimum_wp_version = '${ wpVersion }';`
 		);
+};
+
+/**
+ * Update the minimum supported WP version in phpcs.xml
+ *
+ * @param {string} contents The contents of phpcs.xml
+ * @param {string} latestWPVersion The latest version of WordPress.
+ * @return {string} The new content of phpcs.xml containing the updated WP version.
+ */
+const updateMinWPVersionPHPCS = ( contents, latestWPVersion ) => {
+	const wpVersionList = latestWPVersion.split( '.' );
+	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
+	const regexRequiresAtLeast = /<.*minimum_supported_wp_version.*>/;
+	return contents.replace(
+		regexRequiresAtLeast,
+		`<config name="minimum_supported_wp_version" value="${ wpVersion }" />`
+	);
 };
 
 /**
@@ -284,6 +301,22 @@ const branchHandler = async ( context, octokit, config ) => {
 	);
 
 	if ( ! updatedWooBlockPHPCommit ) return;
+
+	const phpCSPath = 'phpcs.xml';
+	const phpCSUpdateFileMessage = `Update minimum supported wp version in ${ phpCSPath }`;
+
+	const updatePHPCSContent = ( content ) =>
+		updateMinWPVersionPHPCS( content, wpLatestReleaseVersion );
+
+	const updatedPHPCSCommit = await updateFile(
+		context,
+		octokit,
+		phpCSPath,
+		phpCSUpdateFileMessage,
+		updatePHPCSContent
+	);
+
+	if ( ! updatedPHPCSCommit ) return;
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -288,7 +288,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	const {
 		wpLatestReleaseVersion,
 		wcLatestReleaseVersion,
-	} = getWPAndWCReleaseVersions( octokit );
+	} = await getWPAndWCReleaseVersions( octokit );
 
 	const readmePath = 'readme.txt';
 	const readmeUpdateFileMessage = `Update changelog in ${ readmePath }`;

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -198,7 +198,7 @@ const branchHandler = async ( context, octokit, config ) => {
 	}
 
 	const wpTags = await octokit.request(
-		'GET /repos/WordPress/WordPress/git/tags',
+		'GET /repos/WordPress/WordPress/tags',
 		{
 			owner: 'WordPress',
 			repo: 'WordPress',
@@ -217,7 +217,7 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const updatedReadmeMinRequiredVersion = updateMinRequiredVersionsReadme(
 		updatedReadmeChangeLog,
-		wpTags[ 0 ].name
+		wpTags.data[ 0 ].name
 	);
 
 	// Need to convert back to base64 to write to the repo.

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -255,7 +255,7 @@ const branchHandler = async ( context, octokit, config ) => {
 		);
 	};
 
-	const updatedReadmeCommit = updateFile(
+	const updatedReadmeCommit = await updateFile(
 		context,
 		octokit,
 		readmePath,
@@ -275,7 +275,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			wcLatestReleaseVersion
 		);
 
-	const updatedWooBlockPHPCommit = updateFile(
+	const updatedWooBlockPHPCommit = await updateFile(
 		context,
 		octokit,
 		wooBlockPHPPath,

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -53,6 +53,34 @@ const updateMinRequiredVersionsReadme = ( contents, latestWPVersion ) => {
 		.replace( regexTestedUpTo, `Tested up to: ${ version }` );
 };
 
+const updateMinRequiredVersionsWooBlockPHP = (
+	contents,
+	latestWPVersion,
+	latestWCVersion
+) => {
+	const wpVersionList = latestWPVersion.split( '.' );
+	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
+	const wcVersionList = latestWCVersion.split( '.' );
+	const wcVersion = `${ wcVersionList[ 0 ] }.${ wcVersionList[ 1 ] }`;
+	const previousWCVersion =
+		wcVersionList[ 1 ] === '0'
+			? `${ +wcVersionList[ 0 ] - 1 }.9`
+			: `${ wcVersionList[ 0 ] }.${ +wcVersionList[ 1 ] - 1 }`;
+	const regexRequiresAtLeast = /\* Requires at least:.*/;
+	const regexWCRequiresAtLeast = /\* WC requires at least:.*/;
+	const regexWCTestedUpTo = /\* WC tested up to:.*/;
+	return contents
+		.replace( regexRequiresAtLeast, `* Requires at least: ${ wpVersion }` )
+		.replace(
+			regexWCRequiresAtLeast,
+			`* WC requires at least: ${ wcVersion }`
+		)
+		.replace(
+			regexWCTestedUpTo,
+			`* WC tested up to: ${ previousWCVersion }`
+		);
+};
+
 /**
  * @param {GitHubContext} context
  * @param {GitHub} octokit
@@ -204,6 +232,7 @@ const branchHandler = async ( context, octokit, config ) => {
 			repo: 'WordPress',
 		}
 	);
+	const wpLatestReleaseVersion = wpTags.data[ 0 ].name;
 
 	// Content comes from GH API in base64 so convert it to utf-8 string.
 	const readmeBuffer = new Buffer.from( readmeResponse.data.content, 'base64' );
@@ -217,7 +246,7 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const updatedReadmeMinRequiredVersion = updateMinRequiredVersionsReadme(
 		updatedReadmeChangeLog,
-		wpTags.data[ 0 ].name
+		wpLatestReleaseVersion
 	);
 
 	// Need to convert back to base64 to write to the repo.
@@ -242,57 +271,68 @@ const branchHandler = async ( context, octokit, config ) => {
 		return;
 	}
 
-	// const wooBlockPHPResponse = await octokit.repos.getContent( {
-	// 	...context.repo,
-	// 	path: 'woocommerce-gutenberg-products-block.php',
-	// } );
+	// Get WooCommerce data
+	const wcLatestRelease = await octokit.request(
+		'GET /repos/woocommerce/woocommerce/releases/latest',
+		{
+			owner: 'woocommerce',
+			repo: 'woocommerce',
+		}
+	);
 
-	// if ( ! wooBlockPHPResponse ) {
-	// 	debug(
-	// 		`releaseAutomation: Could not read woocommerce-gutenberg-products-block.php file from repository.`
-	// 	);
-	// 	return;
-	// }
+	const wcLatestReleaseVersion = wcLatestRelease.data.name;
 
-	// // Content comes from GH API in base64 so convert it to utf-8 string.
-	// const wooBlockPHPBuffer = new Buffer.from(
-	// 	wooBlockPHPResponse.data.content,
-	// 	'base64'
-	// );
-	// const wooBlockPHPContents = wooBlockPHPBuffer.toString( 'utf-8' );
+	const wooBlockPHPResponse = await octokit.repos.getContent( {
+		...context.repo,
+		path: 'woocommerce-gutenberg-products-block.php',
+	} );
 
-	// // Need to convert back to base64 to write to the repo.
-	// const updatedWooBlockPHPContentBuffer = new Buffer.from(
-	// 	insertNewChangelogEntry(
-	// 		wooBlockPHPContents,
-	// 		changelog,
-	// 		releaseVersion
-	// 	),
-	// 	'utf-8'
-	// );
-	// const updatedWooBlockPHPContent = updatedWooBlockPHPContentBuffer.toString(
-	// 	'base64'
-	// );
+	if ( ! wooBlockPHPResponse ) {
+		debug(
+			`releaseAutomation: Could not read woocommerce-gutenberg-products-block.php file from repository.`
+		);
+		return;
+	}
 
-	// const wooBlockPHPSha = wooBlockPHPResponse.data.sha;
-	// const updatedWooBlockPHPCommit = await octokit.repos.createOrUpdateFileContents(
-	// 	{
-	// 		...context.repo,
-	// 		message:
-	// 			'Update minimum required wc & wp versions in woocommerce-gutenberg-products-block.php',
-	// 		path: 'woocommerce-gutenberg-products-block.php',
-	// 		content: updatedWooBlockPHPContent,
-	// 		sha: wooBlockPHPSha,
-	// 		branch: context.payload.ref,
-	// 	}
-	// );
+	// Content comes from GH API in base64 so convert it to utf-8 string.
+	const wooBlockPHPBuffer = new Buffer.from(
+		wooBlockPHPResponse.data.content,
+		'base64'
+	);
+	const wooBlockPHPContents = wooBlockPHPBuffer.toString( 'utf-8' );
 
-	// if ( ! updatedWooBlockPHPCommit ) {
-	// 	debug(
-	// 		`releaseAutomation: Automatic update of woocommerce-gutenberg-products-block.php failed.`
-	// 	);
-	// 	return;
-	// }
+	// Need to convert back to base64 to write to the repo.
+	const updatedWooBlockPHPContentBuffer = new Buffer.from(
+		updateMinRequiredVersionsWooBlockPHP(
+			wooBlockPHPContents,
+			wpLatestReleaseVersion,
+			wcLatestReleaseVersion
+		),
+		'utf-8'
+	);
+	const updatedWooBlockPHPContent = updatedWooBlockPHPContentBuffer.toString(
+		'base64'
+	);
+
+	const wooBlockPHPSha = wooBlockPHPResponse.data.sha;
+	const updatedWooBlockPHPCommit = await octokit.repos.createOrUpdateFileContents(
+		{
+			...context.repo,
+			message:
+				'Update minimum required wc & wp versions in woocommerce-gutenberg-products-block.php',
+			path: 'woocommerce-gutenberg-products-block.php',
+			content: updatedWooBlockPHPContent,
+			sha: wooBlockPHPSha,
+			branch: context.payload.ref,
+		}
+	);
+
+	if ( ! updatedWooBlockPHPCommit ) {
+		debug(
+			`releaseAutomation: Automatic update of woocommerce-gutenberg-products-block.php failed.`
+		);
+		return;
+	}
 
 	// Add initial Action checklist as comment.
 	const commentBody = lineBreak(

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -211,7 +211,8 @@ const branchHandler = async ( context, octokit, config ) => {
 
 	const updatedReadmeChangeLog = insertNewChangelogEntry(
 		readmeContents,
-		changelog,
+		// changelog,
+		'## My Change log!!',
 		releaseVersion
 	);
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -111,10 +111,15 @@ const updateMinWPVersionPHPCS = ( contents, latestWPVersion ) => {
 	const wpVersionList = latestWPVersion.split( '.' );
 	const wpVersion = `${ wpVersionList[ 0 ] }.${ wpVersionList[ 1 ] }`;
 	const regexRequiresAtLeast = /<.*minimum_supported_wp_version.*>/;
-	return contents.replace(
+
+	const result = contents.replace(
 		regexRequiresAtLeast,
 		`<config name="minimum_supported_wp_version" value="${ wpVersion }" />`
 	);
+
+	debug( `result: ${ result }` );
+
+	return result;
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -16,6 +16,7 @@ const {
 	getReleaseBranch,
 	duplicateChecker,
 	hasMilestone: getHasMilestone,
+	updateFile,
 } = require( './utils' );
 const {
 	getChangelog,
@@ -92,63 +93,6 @@ const updateMinRequiredVersionsWooBlockPHP = (
 			`* WC requires at least: ${ previousWCVersion }`
 		)
 		.replace( regexWCTestedUpTo, `* WC tested up to: ${ wcVersion }` );
-};
-
-/**
- * Callback test.
- *
- * @callback updateContent
- * @param {string} content
- */
-/**
- * @param {GitHubContext} context
- * @param {GitHub} octokit
- * @param {string} path The path of the file to update
- * @param {string} message The message for the reason of the file update
- * @param {updateContent} updateContent callback to update the content of the file
- */
-const updateFile = async ( context, octokit, path, message, updateContent ) => {
-	const contentResponse = await octokit.repos.getContent( {
-		...context.repo,
-		path,
-	} );
-
-	if ( ! contentResponse ) {
-		debug(
-			`releaseAutomation: Could not read ${ path } file from repository.`
-		);
-		return;
-	}
-
-	// Content comes from GH API in base64 so convert it to utf-8 string.
-	const contentBuffer = new Buffer.from(
-		contentResponse.data.content,
-		'base64'
-	);
-	const contents = contentBuffer.toString( 'utf-8' );
-
-	// Need to convert back to base64 to write to the repo.
-	const updatedContentBuffer = new Buffer.from(
-		updateContent( contents ),
-		'utf-8'
-	);
-	const updatedContent = updatedContentBuffer.toString( 'base64' );
-
-	const fileSha = contentResponse.data.sha;
-	const updatedCommit = await octokit.repos.createOrUpdateFileContents( {
-		...context.repo,
-		message,
-		path,
-		content: updatedContent,
-		sha: fileSha,
-		branch: context.payload.ref,
-	} );
-
-	if ( ! updatedCommit ) {
-		debug( `releaseAutomation: Automatic update of ${ path } failed.` );
-	}
-
-	return updatedCommit;
 };
 
 /**

--- a/lib/automations/release/utils/get-wp-wc-release-versions.js
+++ b/lib/automations/release/utils/get-wp-wc-release-versions.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {import('../../../typedefs').GitHub} GitHub
+ */
+
+/**
+ * @param {GitHub} octokit
+ */
+module.exports = async ( octokit ) => {
+	const wpTags = await octokit.request(
+		'GET /repos/WordPress/WordPress/tags',
+		{
+			owner: 'WordPress',
+			repo: 'WordPress',
+		}
+	);
+	const wpLatestReleaseVersion = wpTags.data[ 0 ].name;
+
+	const wcLatestRelease = await octokit.request(
+		'GET /repos/woocommerce/woocommerce/releases/latest',
+		{
+			owner: 'woocommerce',
+			repo: 'woocommerce',
+		}
+	);
+
+	const wcLatestReleaseVersion = wcLatestRelease.data.name;
+
+	return {
+		wpLatestReleaseVersion,
+		wcLatestReleaseVersion,
+	};
+};

--- a/lib/automations/release/utils/index.js
+++ b/lib/automations/release/utils/index.js
@@ -1,5 +1,6 @@
 module.exports = {
 	getReleaseVersion: require( './get-release-version' ),
+	getWPAndWCReleaseVersions: require( './get-wp-wc-release-versions' ),
 	isPatchRelease: require( './is-patch-release' ),
 	getReleaseBranch: require( './get-release-branch' ),
 	duplicateChecker: require( './duplicate-pr-checker' ),

--- a/lib/automations/release/utils/index.js
+++ b/lib/automations/release/utils/index.js
@@ -5,4 +5,5 @@ module.exports = {
 	getReleaseBranch: require( './get-release-branch' ),
 	duplicateChecker: require( './duplicate-pr-checker' ),
 	hasMilestone: require( './has-milestone' ),
+	updateFile: require( './update-file' ),
 };

--- a/lib/automations/release/utils/update-file.js
+++ b/lib/automations/release/utils/update-file.js
@@ -1,0 +1,63 @@
+const debug = require( '../../../debug' );
+
+/**
+ * @typedef {import('../../typedefs').GitHubContext} GitHubContext
+ * @typedef {import('../../../typedefs').GitHub} GitHub
+ */
+
+/**
+ * Callback test.
+ *
+ * @callback updateContent
+ * @param {string} content
+ */
+/**
+ * @param {GitHubContext} context
+ * @param {GitHub} octokit
+ * @param {string} path The path of the file to update
+ * @param {string} message The message for the reason of the file update
+ * @param {updateContent} updateContent callback to update the content of the file
+ */
+module.exports = async ( context, octokit, path, message, updateContent ) => {
+	const contentResponse = await octokit.repos.getContent( {
+		...context.repo,
+		path,
+	} );
+
+	if ( ! contentResponse ) {
+		debug(
+			`releaseAutomation: Could not read ${ path } file from repository.`
+		);
+		return;
+	}
+
+	// Content comes from GH API in base64 so convert it to utf-8 string.
+	const contentBuffer = new Buffer.from(
+		contentResponse.data.content,
+		'base64'
+	);
+	const contents = contentBuffer.toString( 'utf-8' );
+
+	// Need to convert back to base64 to write to the repo.
+	const updatedContentBuffer = new Buffer.from(
+		updateContent( contents ),
+		'utf-8'
+	);
+	const updatedContent = updatedContentBuffer.toString( 'base64' );
+
+	const fileSha = contentResponse.data.sha;
+	const updatedCommit = await octokit.repos.createOrUpdateFileContents( {
+		...context.repo,
+		message,
+		path,
+		content: updatedContent,
+		sha: fileSha,
+		branch: context.payload.ref,
+	} );
+
+	if ( ! updatedCommit ) {
+		debug( `releaseAutomation: Automatic update of ${ path } failed.` );
+	}
+
+	return updatedCommit;
+};


### PR DESCRIPTION
This PR automates updating the requirement for WordPress and WooCommerce version support. Before, we needed to manually update various places in the codebase whenever we bump minimum version support.

- `readme.txt`
- `woocommerce-gutenberg-products-block.php`
- `phpcs.xml`

# Testing
To test this, you will need to:
- **Fork** the `woocommerce-gutenberg-products-block` and then unfork it (Go to this url: https://support.github.com/contact?tags=rr-forks and type `unfork` into the subject line. Follow the steps from the virtual assistant and wait 5-10 mins for the request to be actioned).
- Enable issues on your new unforked repository (go to `Settings > General > Features > Issues`)
- Activate GH actions
- Give read and write permissions to the workflows: Settings > Actions > General > Workflow permissions
- Allow GH actions to create PRs: Settings > Actions > General
- Create a milestone (I used 9.9.0, but pick whatever you like)
- Clone your repository locally.
- Create a PR on your repository, in this PR you should change the following file: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/.github/workflows/release-pull-request.yml#L27
- Change the highlighted line to read: `uses: woocommerce/automations@add/min-required-wc-wp-versions`
- Merge the PR
- Optionally create multiple PRs.
- Assign them all to the milestone you created earlier.
- Create a new branch, `release/9.9.0` or whatever milestone number you picked.
- Push this branch to the remote.
- Go to your repository on GitHub, you should see a new PR created for the release, and it should have updated WordPress and WooCommerce versions in `readme.txt`, `woocommerce-gutenberg-products-block.php`, & `phpcs.xml`. 🙌🏼 

## TODO

- [x] Some refactoring is needed: we are handling the `.txt` & `.PHP` files in the same manner. Creating a common function will make the code cleaner!