### PR TITLE
Release process: automatically close milestone when starting the release

### DIFF
--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -7,7 +7,7 @@ const core = require( '@actions/core' );
  * Internal dependencies
  */
 const { getTemplate, TEMPLATES, compile } = require( './templates' );
-const { lineBreak } = require( '../../utils' );
+const { lineBreak, getMilestoneByTitle } = require( '../../utils' );
 const debug = require( '../../debug' );
 const {
 	getReleaseVersion,
@@ -328,6 +328,60 @@ const branchHandler = async ( context, octokit, config ) => {
 		issue_number: prCreated.data.number,
 		body: commentBody,
 	} );
+
+	// Get existing milestone
+	const milestone = await getMilestoneByTitle(
+		context,
+		octokit,
+		releaseVersion,
+		'open'
+	);
+	const milestoneNumber = milestone.number;
+	const milestoneTitle = milestone.title
+		.replace( '"', '' )
+		.replace( '[', '' )
+		.replace( ']', '' );
+	// Close existing milestone
+	const milestoneUpdate = await octokit.issues.updateMilestone( {
+		owner: owner,
+		repo: repo,
+		milestone_number: milestoneNumber,
+		state: 'closed',
+	} );
+	if ( ! milestoneUpdate ) {
+		debug(
+			`releaseAutomation: Could not close the milestone: ${ milestoneTitle }`
+		);
+		return;
+	}
+	debug(
+		`releaseAutomation: Successfully milestone closed: ${ milestoneTitle }`
+	);
+	// Create new milestone if it's not a patch release
+	if ( ! isPatchRelease( releaseVersion ) ) {
+		const milestoneTitleArray = milestoneTitle.split( '.' );
+		const nextMilestone =
+			parseInt( milestoneTitleArray[ 1 ] ) < 9
+				? `${ milestoneTitleArray[ 0 ] }.${
+						parseInt( milestoneTitleArray[ 1 ] ) + 1
+					}.0`
+				: `${ parseInt( milestoneTitleArray[ 0 ] ) + 1 }.0.0`;
+		const createMilestone = await octokit.issues.createMilestone( {
+			owner: owner,
+			repo: repo,
+			title: nextMilestone,
+			state: 'open',
+		} );
+		if ( ! createMilestone ) {
+			debug(
+				`releaseAutomation: Could not create the  new milestone: ${ nextMilestone }`
+			);
+			return;
+		}
+		debug(
+			`releaseAutomation: Created a new milestone: ${ nextMilestone }`
+		);
+	}
 };
 
 /**

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -337,10 +337,10 @@ const branchHandler = async ( context, octokit, config ) => {
 		'open'
 	);
 	const milestoneNumber = milestone.number;
-	const milestoneTitle = milestone.title
-		.replace( '"', '' )
-		.replace( '[', '' )
-		.replace( ']', '' );
+
+	// Remove quotes and brackets from milestone title
+	const milestoneTitle = milestone.title.replace( /["\[\]]/g, '' );
+	
 	// Close existing milestone
 	const milestoneUpdate = await octokit.issues.updateMilestone( {
 		owner: owner,


### PR DESCRIPTION
This PR adds more functionality to the release PR automation, it closes the existing milestone of the release and creates the next milestone. 

## Changes
- Added the code to close existing milestones and create the next milestone in `lib/automations/release/branch-create-handler.js`


# Testing
To test this, you will need to:
- **Fork** the `woocommerce-gutenberg-products-block` and then unfork it (Go to this url: https://support.github.com/contact?tags=rr-forks and type `unfork` into the subject line. Follow the steps from the virtual assistant and wait 5-10 mins for the request to be actioned).
- Enable issues on your new unforked repository (go to `Settings > General > Features > Issues`)
- Activate GH actions
- Give read and write permissions to the workflows: Settings > Actions > General > Workflow permissions
- Allow GH actions to create PRs: Settings > Actions > General
- Create a milestone (Example: 11.1.0)
- Clone your repository locally.
- Create a PR on your repository, in this PR, you should change the following file: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/.github/workflows/release-pull-request.yml#L27
- Change the highlighted line to read: `uses: woocommerce/automations@add/close-milestone`
- Merge the PR
- Create a new branch `release/11.1.0` (same as your milestone number)
- Go to actions and confirm the `Release Pull Request Automation ` task is completed successfully. 
- Go to milestones and confirm existing milestone is closed, and the next milestone is created successfully. 