### PR TITLE
Release process: automatically set milestone date after a successful release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
                 'major' - Assign to the next major version.
         required: false
         default: minor
+    target_milestone:
+        description: |
+            Milestone title for modifying any milestone.
+        required: false
+        default: ''
 runs:
     using: 'node12'
     main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
         default: minor
     target_milestone:
         description: |
-            Milestone title for modifying any milestone.
+            Title of the milestone that will be updated.
         required: false
         default: ''
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -455,7 +455,10 @@ const {
  */
 const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 	const regex = /== Changelog ==\n/;
-	return contents.replace( regex, `== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`);
+	return contents.replace(
+		regex,
+		`== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`
+	);
 }
 /**
  * @param {GitHubContext} context

--- a/lib/automations.js
+++ b/lib/automations.js
@@ -9,4 +9,5 @@ module.exports = [
 	require( './automations/todos' ),
 	require( './automations/release' ),
 	require( './automations/assign-milestone' ),
+	require( './automations/update-milestone' ),
 ];

--- a/lib/automations/update-milestone/README.md
+++ b/lib/automations/update-milestone/README.md
@@ -1,0 +1,41 @@
+## Update Milestone Automation
+
+When a release is completed, this automation will update the due date of its milestone to current date.
+
+## Usage
+
+To implement this action, include it in your workflow configuration file:
+
+```yaml
+on:
+    release:
+        types: [published]
+jobs:
+    tag:
+        name: New Release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: 'Get Previous tag'
+              id: previoustag
+              uses: "WyriHaximus/github-action-get-previous-tag@v1"
+            - name: Set milestone due date
+              uses: woocommerce/automations@v1
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                automations: update-milestone
+                target_milestone: ${{ steps.previoustag.outputs.tag }}
+```
+
+## API
+
+### Inputs
+
+- `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
+- `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
+- `target_milestone`: Optional. For the update-milestone workflow, this controls which milestone due date needs to be updated.
+
+### Outputs
+
+_None._

--- a/lib/automations/update-milestone/get-config.js
+++ b/lib/automations/update-milestone/get-config.js
@@ -15,7 +15,7 @@ const getInput = ( input ) => {
 	const value = coreGetInput( input.input ) || input.default;
 	if ( input.required && ! value ) {
 		throw new Error(
-			`Update Milestone: Missing required input ${ input.input } your input: ${ input }`
+			`Update Milestone: Missing required input ${ input.input }`
 		);
 	}
 

--- a/lib/automations/update-milestone/get-config.js
+++ b/lib/automations/update-milestone/get-config.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+const { setFailed, getInput: coreGetInput } = require( '@actions/core' );
+
+const inputs = {
+	targetMilestone: {
+		input: 'target_milestone',
+		default: '',
+		required: false,
+	},
+};
+
+const getInput = ( input ) => {
+	const value = coreGetInput( input.input ) || input.default;
+	if ( input.required && ! value ) {
+		throw new Error(
+			`Update Milestone: Missing required input ${ input.input } your input: ${ input }`
+		);
+	}
+
+	return value;
+};
+
+module.exports = async () => {
+	try {
+		return {
+			targetMilestone: getInput( inputs.targetMilestone ),
+		};
+	} catch ( error ) {
+		setFailed( `Update Milestone: Target milestone: ${ error }` );
+	}
+};

--- a/lib/automations/update-milestone/index.js
+++ b/lib/automations/update-milestone/index.js
@@ -1,0 +1,9 @@
+const runner = require( './runner' );
+const getConfig = require( './get-config' );
+
+module.exports = {
+	name: 'update-milestone',
+	events: [ 'release' ],
+	runner,
+	getConfig,
+};

--- a/lib/automations/update-milestone/runner.js
+++ b/lib/automations/update-milestone/runner.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+const { setFailed } = require( '@actions/core' );
+
+/**
+ * Internal dependencies
+ */
+const debug = require( '../../debug' );
+const updateMilestoneHandler = require( './update-milestone-handler' );
+
+/**
+ * @typedef {import('@actions/github').GitHub} GitHub
+ * @typedef {import('@actions/github').context} GitHubContext
+ * @typedef {import('../../typedefs').AutomationTaskRunner} AutomationTaskRunner
+ */
+
+const runnerMatrix = {
+	release: {
+		published: updateMilestoneHandler,
+	},
+};
+
+/**
+ * The task runner for this action
+ *
+ * @param {string} eventName The event we want the runner for.
+ * @param {string} [action]  The action we want the runner for.
+ *
+ * @return {AutomationTaskRunner} A runner function.
+ */
+const getRunnerTask = ( eventName, action ) => {
+	if (
+		! runnerMatrix[ eventName ] ||
+		action === undefined ||
+		! runnerMatrix[ eventName ][ action ]
+	) {
+		return;
+	}
+	return runnerMatrix[ eventName ][ action ];
+};
+
+/**
+ * The task runner for this action to update the milestone
+ *
+ * @param {GitHubContext} context Context for the job run (github).
+ * @param {GitHub}        octokit GitHub api helper.
+ * @param {Object}        config  Config object.
+ *
+ * @return {AutomationTaskRunner} task runner.
+ */
+const runner = async ( context, octokit, config ) => {
+	const task = getRunnerTask( context.eventName, context.payload.action );
+	if ( typeof task === 'function' ) {
+		debug( `Update Milestone: Executing the ${ task.name } task.` );
+		await task( context, octokit, config );
+	} else {
+		setFailed(
+			`Update Milestone: There is no configured task for the event = '${ context.eventName }' and the payload action = '${ context.payload.action }'`
+		);
+	}
+};
+
+module.exports = runner;

--- a/lib/automations/update-milestone/test/update-milestone-handler.js
+++ b/lib/automations/update-milestone/test/update-milestone-handler.js
@@ -1,0 +1,37 @@
+const { gimmeOctokit, gimmeContext, gimmeApp } = require( '@testHelpers' );
+
+describe( 'Update milestone after successful release', () => {
+	let octokit, context, app;
+	beforeEach( () => {
+		octokit = gimmeOctokit();
+		context = gimmeContext( 'release', 'published' );
+		app = gimmeApp( 'update-milestone' );
+	} );
+	it( 'Does not updates the milestone if milestone not present', async () => {
+		await app( context, octokit, {
+			targetMilestone: '6.0.0',
+		} );
+		expect(
+			octokit.issues.listMilestones.endpoint.merge
+		).toHaveBeenCalled();
+		expect( octokit.issues.updateMilestone ).not.toHaveBeenCalled();
+	} );
+	it( 'Does not updates the milestone if milestone have a due date', async () => {
+		await app( context, octokit, {
+			targetMilestone: '7.0.0',
+		} );
+		expect(
+			octokit.issues.listMilestones.endpoint.merge
+		).toHaveBeenCalled();
+		expect( octokit.issues.updateMilestone ).not.toHaveBeenCalled();
+	} );
+	it( 'Updates the milestone if milestone is present and has no due date', async () => {
+		await app( context, octokit, {
+			targetMilestone: '5.0.0',
+		} );
+		expect(
+			octokit.issues.listMilestones.endpoint.merge
+		).toHaveBeenCalled();
+		expect( octokit.issues.updateMilestone ).toHaveBeenCalled();
+	} );
+} );

--- a/lib/automations/update-milestone/test/update-milestone-handler.js
+++ b/lib/automations/update-milestone/test/update-milestone-handler.js
@@ -7,7 +7,7 @@ describe( 'Update milestone after successful release', () => {
 		context = gimmeContext( 'release', 'published' );
 		app = gimmeApp( 'update-milestone' );
 	} );
-	it( 'Does not updates the milestone if milestone not present', async () => {
+	it( 'Does not update the milestone if the milestone is not present', async () => {
 		await app( context, octokit, {
 			targetMilestone: '6.0.0',
 		} );

--- a/lib/automations/update-milestone/test/update-milestone-handler.js
+++ b/lib/automations/update-milestone/test/update-milestone-handler.js
@@ -16,7 +16,7 @@ describe( 'Update milestone after successful release', () => {
 		).toHaveBeenCalled();
 		expect( octokit.issues.updateMilestone ).not.toHaveBeenCalled();
 	} );
-	it( 'Does not updates the milestone if milestone have a due date', async () => {
+	it( 'Does not update the milestone if the milestone has a due date', async () => {
 		await app( context, octokit, {
 			targetMilestone: '7.0.0',
 		} );

--- a/lib/automations/update-milestone/update-milestone-handler.js
+++ b/lib/automations/update-milestone/update-milestone-handler.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+const debug = require( '../../debug' );
+const { getMilestoneByTitle } = require( '../../utils' );
+
+/**
+ * @typedef {import('../../typedefs').GitHubContext} GitHubContext
+ * @typedef {import('../../typedefs').GitHub} GitHub
+ */
+
+/**
+ * @param {GitHubContext} context
+ * @param {GitHub} octokit
+ * @param {Object} config
+ */
+module.exports = async ( context, octokit, config ) => {
+	const targetMilestone = await getMilestoneByTitle(
+		context,
+		octokit,
+		config.targetMilestone,
+		'closed'
+	);
+
+	if ( ! targetMilestone ) {
+		debug(
+			`Update Milestone: Could not find the target milestone: ${ config.targetMilestone }`
+		);
+		return;
+	}
+	debug(
+		`Update Milestone: Found the target milestone: ${ config.targetMilestone }`
+	);
+
+	if ( targetMilestone.due_on !== null ) {
+		debug(
+			`Update Milestone: Target milestone: ${ config.targetMilestone } already have a due date.`
+		);
+		return;
+	}
+
+	const updateDueDate = ( milestoneNumber, dueDate ) => {
+		return octokit.issues.updateMilestone( {
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			milestone_number: milestoneNumber,
+			due_on: dueDate,
+		} );
+	};
+
+	const date = new Date();
+	const dueDate = date.toISOString();
+
+	const milestoneUpdate = await updateDueDate(
+		targetMilestone.number,
+		dueDate
+	);
+
+	if ( ! milestoneUpdate ) {
+		debug(
+			`Update Milestone: Could not update the due date of the milestone: ${ config.targetMilestone }`
+		);
+		return;
+	}
+
+	debug(
+		`Update Milestone: Milstone ${ config.targetMilestone } successfully updated with the ${ dueDate } due date.`
+	);
+};

--- a/lib/automations/update-milestone/update-milestone-handler.js
+++ b/lib/automations/update-milestone/update-milestone-handler.js
@@ -34,7 +34,7 @@ module.exports = async ( context, octokit, config ) => {
 
 	if ( targetMilestone.due_on !== null ) {
 		debug(
-			`Update Milestone: Target milestone: ${ config.targetMilestone } already have a due date.`
+			`Update Milestone: Target milestone: ${ config.targetMilestone } already has a due date.`
 		);
 		return;
 	}

--- a/lib/automations/update-milestone/update-milestone-handler.js
+++ b/lib/automations/update-milestone/update-milestone-handler.js
@@ -64,6 +64,6 @@ module.exports = async ( context, octokit, config ) => {
 	}
 
 	debug(
-		`Update Milestone: Milstone ${ config.targetMilestone } successfully updated with the ${ dueDate } due date.`
+		`Update Milestone: Milestone ${ config.targetMilestone } successfully updated with the ${ dueDate } due date.`
 	);
 };

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -82,6 +82,9 @@ exports.gimmeOctokit = () => {
 						.mockName( 'issues.listForRepo.endpoint.merge' ),
 				},
 			},
+			updateMilestone: jest
+				.fn( () => Promise.resolve( { data: true } ) )
+				.mockName( 'issues.updateMilestone' ),
 		},
 		git: {
 			getCommit: jest
@@ -137,6 +140,16 @@ exports.gimmeOctokit = () => {
 										{ title: '3.0.1', number: 301 },
 										{ title: '3.1.0', number: 310 },
 										{ title: '4.0.0', number: 400 },
+										{
+											title: '5.0.0',
+											number: 6,
+											due_on: null,
+										},
+										{
+											title: '7.0.0',
+											number: 8,
+											due_on: '2022-12-21T11:11:05Z',
+										},
 									],
 								},
 							] )();


### PR DESCRIPTION
This PR adds a new automation that will update the milestone due date after the release. 

## Changes
- Added a new automation in `lib\automations\update-milestone` folder. 
- Updated the `action.yml` file to read the target milestone number. 


# Testing
To test this, you will need to:
- **Fork** the `woocommerce-gutenberg-products-block` and then unfork it (Go to this url: https://support.github.com/contact?tags=rr-forks and type `unfork` into the subject line. Follow the steps from the virtual assistant and wait 5-10 mins for the request to be actioned).
- Enable issues on your new unforked repository (go to `Settings > General > Features > Issues`)
- Activate GH actions
- Give read and write permissions to the workflows: Settings > Actions > General > Workflow permissions
- Allow GH actions to create PRs: Settings > Actions > General
- Create a milestone (Example: 11.1.0) and close the milestone
- Replace your [wordpress-deploy.yml](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/.github/workflows/wordpress-deploy.yml) file with [wordpress-deploy.yml](https://github.com/tarunvijwani/woocommerce-blocks/blob/trunk/.github/workflows/wordpress-deploy.yml). It will remove the deployment steps. 
- Create a new milestone say 11.0.0 without any due date and close it. 
- Draft a new release from https://github.com/tarunvijwani/woocommerce-blocks/releases/new
- Give the milestone number in name and tag.
- Publish the release. 
- Go to actions and wait for [wordpress-deploy.yml](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/.github/workflows/wordpress-deploy.yml) to finish.
- If it fails, check the debug logs. (It might get fail because we don't have any PR assigned to the milestone for the release)
- Check and confirm milestone is updated with the due date.
- Please test around this. 