### PR TITLE
Add documentation for update-milestone automation

### DIFF
--- a/lib/automations/update-milestone/README.md
+++ b/lib/automations/update-milestone/README.md
@@ -1,0 +1,41 @@
+## Update Milestone Automation
+
+When a release is completed, this automation will update the due date of its milestone to current date.
+
+## Usage
+
+To implement this action, include it in your workflow configuration file:
+
+```yaml
+on:
+    release:
+        types: [published]
+jobs:
+    tag:
+        name: New Release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: 'Get Previous tag'
+              id: previoustag
+              uses: "WyriHaximus/github-action-get-previous-tag@v1"
+            - name: Set milestone due date
+              uses: woocommerce/automations@v1
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                automations: update-milestone
+                target_milestone: ${{ steps.previoustag.outputs.tag }}
+```
+
+## API
+
+### Inputs
+
+- `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
+- `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
+- `target_milestone`: Optional. For the update-milestone workflow, this controls which milestone due date needs to be updated.
+
+### Outputs
+
+_None._


### PR DESCRIPTION
This PR adds the documentation for the `update-milestone` automation.

### Changes in the PR
- Add the `README.MD` file for the `update-milestone` automation.

### Testing
1. Navigate to the [documentation page](https://github.com/woocommerce/automations/tree/b8fc1c63750e306b9a647dea3f74aece866245d2/lib/automations/update-milestone).
2. Confirm the content mentioned in the document is correct.