### PR TITLE
Automatically add `type: release` and `skip-changelog` to release PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6,7 +6,7 @@ module.exports =
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse("{\"labelTypePrefix\":\"type: \",\"labelTypeMap\":{\"bug\":\"Bug Fixes\",\"regression\":\"Bug Fixes\",\"feature\":\"Features\",\"enhancement\":\"Enhancements\",\"new api\":\"New APIs\",\"experimental\":\"Experiments\",\"task\":\"Various\"},\"groupTitleOrder\":[\"Features\",\"Enhancements\",\"New APIs\",\"Bug Fixes\",\"Performance\",\"Experiments\",\"Documentation\",\"Code Quality\",\"undefined\",\"Various\"],\"rewordTerms\":{\"e2e\":\"end-to-end\",\"url\":\"URL\",\"config\":\"configuration\",\"docs\":\"documentation\"},\"needsDevNoteLabel\":\"status:needs-dev-note\",\"labelsToOmit\":[\"skip-changelog\"]}");
+module.exports = JSON.parse("{\"labelTypePrefix\":\"type: \",\"labelTypeMap\":{\"bug\":\"Bug Fixes\",\"regression\":\"Bug Fixes\",\"feature\":\"Features\",\"enhancement\":\"Enhancements\",\"new api\":\"New APIs\",\"experimental\":\"Experiments\",\"task\":\"Various\"},\"groupTitleOrder\":[\"Features\",\"Enhancements\",\"New APIs\",\"Bug Fixes\",\"Performance\",\"Experiments\",\"Documentation\",\"Code Quality\",\"undefined\",\"Various\"],\"rewordTerms\":{\"e2e\":\"end-to-end\",\"url\":\"URL\",\"config\":\"configuration\",\"docs\":\"documentation\"},\"needsDevNoteLabel\":\"status:needs-dev-note\",\"labelsToOmit\":[\"skip-changelog\"],\"releasePRLabels\":[\"skip-changelog\",\"type: release\"]}");
 
 /***/ }),
 
@@ -459,9 +459,11 @@ const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 	const regex = /== Changelog ==\n/;
 	return contents.replace(
 		regex,
-		`== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`
+		`== Changelog ==\n\n= ${ releaseVersion } - ${
+			new Date().toISOString().split( 'T' )[ 0 ]
+		} =\n\n${ changelog }`
 	);
-}
+};
 
 /**
  * Inserts the new changelog entry into the readme file contents
@@ -740,6 +742,12 @@ const branchHandler = async ( context, octokit, config ) => {
 	const commentBody = lineBreak(
 		compile( initialChecklistTemplate )( templateData )
 	);
+
+	await octokit.issues.addLabels( {
+		...context.repo,
+		issue_number: prCreated.data.number,
+		labels: config.releasePRLabels,
+	} );
 
 	await octokit.issues.createComment( {
 		...context.repo,

--- a/lib/automations/release/README.md
+++ b/lib/automations/release/README.md
@@ -4,21 +4,20 @@ This automation handles automating various parts of a somewhat opinionated relea
 
 Currently:
 
--   it reacts to the `create` (create branch) event (which is triggered when you [create a branch using the GitHub UI](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch)).
--   if a created branch has the format `release/x.x.x` where `x.x.x` is the version being released...
-
-    -   automation will check if there's already a pull request created for this release branch and if yes then stop here. Otherwise...
-    -   will create a pull request using `.github/release-pull-request.md` or `.github/patch-release-pull-request.md` templates found in the project's repo or falling back to the templates in this action.
-    -   will generate and add the changelog for the release to the pull request description (using the configuration provided in the project's `.github/release-automation-config.json` file).
-    -   will generate a release checklist using the `.github/release-initial-checklist.md` or `.github/patch-initial-checklist.md` templates and add as a comment on the pull request for the branch.
-
+- it reacts to the `create` (create branch) event (which is triggered when you [create a branch using the GitHub UI](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch)).
+- if a created branch has the format `release/x.x.x` where `x.x.x` is the version being released...
+  - automation will check if there's already a pull request created for this release branch and if yes then stop here. Otherwise...
+  - will create a pull request using `.github/release-pull-request.md` or `.github/patch-release-pull-request.md` templates found in the project's repo or falling back to the templates in this action.
+  - will generate and add the changelog for the release to the pull request description (using the configuration provided in the project's `.github/release-automation-config.json` file).
+  - will generate a release checklist using the `.github/release-initial-checklist.md` or `.github/patch-initial-checklist.md` templates and add as a comment on the pull request for the branch.
+  
 ### Changelog generation
 
 This automation will automatically generate a changelog from all the closed pull requests in the milestone matching the release version. So if your release branch is `release/3.1.0` then a milestone with the title `3.1.0` will be looked for and if it exists, all closed prs in that milestone will be used for generating the changelog.
 
 The changelog entry will be generated:
 
--   Using the special formatted changelog entry in the pull request body if it exists. Otherwise the pull request title is used. Example:
+- Using the special formatted changelog entry in the pull request body if it exists. Otherwise the pull request title is used. Example:
 
 ```
 ### Changelog
@@ -26,8 +25,8 @@ The changelog entry will be generated:
 > This is a custom changelog note.
 ```
 
--   Using labels to group changelog entries by type (following the labels in the automation config).
--   If no matching label, attempt to derive the type from the text of the entry (i.e. the word "Fixed" would trigger belonging to "Bug" group).
+- Using labels to group changelog entries by type (following the labels in the automation config).
+- If no matching label, attempt to derive the type from the text of the entry (i.e. the word "Fixed" would trigger belonging to "Bug" group). 
 
 ## Usage
 
@@ -69,25 +68,25 @@ You can customize the output of various content in the pull request via adding t
 
 The following templates are used for the pull request description:
 
-| Template file name        | Used when...                                                              |
-| ------------------------- | ------------------------------------------------------------------------- |
-| `release-pull-request.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`) |
-| `patch-pull-request.md`   | The release is a patch release (i.e. `3.2.2` or `4.0.1`)                  |
+| Template file name | Used when... |
+| ------------------ | ------------ |
+| `release-pull-request.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`)
+| `patch-pull-request.md` | The release is a patch release (i.e. `3.2.2` or `4.0.1`)
 
 Templates utilize handlebars template format and will receive the following variables:
 
--   `version`: Implemented by `{{version}}`. This will be replaced by the detected version from the release branch.
--   `changelog`: Implemented by `{{changelog}}`. This will be replaced by the generated changelog.
--   `devNoteItems`: Implemented by `{{devNoteItems}}`. This will be replaced by any changelog items designated as a dev note.
+- `version`: Implemented by `{{version}}`. This will be replaced by the detected version from the release branch.
+- `changelog`: Implemented by `{{changelog}}`. This will be replaced by the generated changelog.
+- `devNoteItems`: Implemented by `{{devNoteItems}}`. This will be replaced by any changelog items designated as a dev note.
 
 ### Release checklist (added as a comment on the pull request)
 
 The following templates are used for the release checklist added as a comment on the pull request.
 
-| Template file name             | Used when...                                                              |
-| ------------------------------ | ------------------------------------------------------------------------- |
-| `release-initial-checklist.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`) |
-| `patch-initial-checklist.md`   | The release is a patch release (i.e. `3.2.2` or `4.0.1`)                  |
+| Template file name | Used when... |
+| ------------------ | ------------ |
+| `release-initial-checklist.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`)
+| `patch-initial-checklist.md` | The release is a patch release (i.e. `3.2.2` or `4.0.1`)
 
 The same variables are available in these templates as were available in the pull request description templates.
 
@@ -99,7 +98,7 @@ The configuration file has the following properties:
 
 **`labelTypeMap`** and `labelType
 
-These will map label types to a heading for grouping the changelog. For instance if you prefix your issue types with `type:` (eg. `type: bug`), then you would give the `labelTypePrefix` a value of `type:` and implement `bug` as a property in the `labelTypeMap`.
+These will map label types to a heading for grouping the changelog. For instance if you prefix your issue types with `type:` (eg. `type: bug`), then you would give the `labelTypePrefix` a value of `type: ` and implement `bug` as a property in the `labelTypeMap`.
 
 **`groupTitleOrder`**
 
@@ -127,8 +126,8 @@ You can add any labels here which will be attached to the new PR automatically c
 
 ### Inputs
 
--   `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
--   `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
+- `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
+- `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
 
 ### Outputs
 

--- a/lib/automations/release/README.md
+++ b/lib/automations/release/README.md
@@ -4,20 +4,21 @@ This automation handles automating various parts of a somewhat opinionated relea
 
 Currently:
 
-- it reacts to the `create` (create branch) event (which is triggered when you [create a branch using the GitHub UI](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch)).
-- if a created branch has the format `release/x.x.x` where `x.x.x` is the version being released...
-  - automation will check if there's already a pull request created for this release branch and if yes then stop here. Otherwise...
-  - will create a pull request using `.github/release-pull-request.md` or `.github/patch-release-pull-request.md` templates found in the project's repo or falling back to the templates in this action.
-  - will generate and add the changelog for the release to the pull request description (using the configuration provided in the project's `.github/release-automation-config.json` file).
-  - will generate a release checklist using the `.github/release-initial-checklist.md` or `.github/patch-initial-checklist.md` templates and add as a comment on the pull request for the branch.
-  
+-   it reacts to the `create` (create branch) event (which is triggered when you [create a branch using the GitHub UI](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch)).
+-   if a created branch has the format `release/x.x.x` where `x.x.x` is the version being released...
+
+    -   automation will check if there's already a pull request created for this release branch and if yes then stop here. Otherwise...
+    -   will create a pull request using `.github/release-pull-request.md` or `.github/patch-release-pull-request.md` templates found in the project's repo or falling back to the templates in this action.
+    -   will generate and add the changelog for the release to the pull request description (using the configuration provided in the project's `.github/release-automation-config.json` file).
+    -   will generate a release checklist using the `.github/release-initial-checklist.md` or `.github/patch-initial-checklist.md` templates and add as a comment on the pull request for the branch.
+
 ### Changelog generation
 
 This automation will automatically generate a changelog from all the closed pull requests in the milestone matching the release version. So if your release branch is `release/3.1.0` then a milestone with the title `3.1.0` will be looked for and if it exists, all closed prs in that milestone will be used for generating the changelog.
 
 The changelog entry will be generated:
 
-- Using the special formatted changelog entry in the pull request body if it exists. Otherwise the pull request title is used. Example:
+-   Using the special formatted changelog entry in the pull request body if it exists. Otherwise the pull request title is used. Example:
 
 ```
 ### Changelog
@@ -25,8 +26,8 @@ The changelog entry will be generated:
 > This is a custom changelog note.
 ```
 
-- Using labels to group changelog entries by type (following the labels in the automation config).
-- If no matching label, attempt to derive the type from the text of the entry (i.e. the word "Fixed" would trigger belonging to "Bug" group). 
+-   Using labels to group changelog entries by type (following the labels in the automation config).
+-   If no matching label, attempt to derive the type from the text of the entry (i.e. the word "Fixed" would trigger belonging to "Bug" group).
 
 ## Usage
 
@@ -68,25 +69,25 @@ You can customize the output of various content in the pull request via adding t
 
 The following templates are used for the pull request description:
 
-| Template file name | Used when... |
-| ------------------ | ------------ |
-| `release-pull-request.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`)
-| `patch-pull-request.md` | The release is a patch release (i.e. `3.2.2` or `4.0.1`)
+| Template file name        | Used when...                                                              |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `release-pull-request.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`) |
+| `patch-pull-request.md`   | The release is a patch release (i.e. `3.2.2` or `4.0.1`)                  |
 
 Templates utilize handlebars template format and will receive the following variables:
 
-- `version`: Implemented by `{{version}}`. This will be replaced by the detected version from the release branch.
-- `changelog`: Implemented by `{{changelog}}`. This will be replaced by the generated changelog.
-- `devNoteItems`: Implemented by `{{devNoteItems}}`. This will be replaced by any changelog items designated as a dev note.
+-   `version`: Implemented by `{{version}}`. This will be replaced by the detected version from the release branch.
+-   `changelog`: Implemented by `{{changelog}}`. This will be replaced by the generated changelog.
+-   `devNoteItems`: Implemented by `{{devNoteItems}}`. This will be replaced by any changelog items designated as a dev note.
 
 ### Release checklist (added as a comment on the pull request)
 
 The following templates are used for the release checklist added as a comment on the pull request.
 
-| Template file name | Used when... |
-| ------------------ | ------------ |
-| `release-initial-checklist.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`)
-| `patch-initial-checklist.md` | The release is a patch release (i.e. `3.2.2` or `4.0.1`)
+| Template file name             | Used when...                                                              |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `release-initial-checklist.md` | The release is not a patch release (i.e. `4.1.0`, or `3.2.0`, or `4.0.0`) |
+| `patch-initial-checklist.md`   | The release is a patch release (i.e. `3.2.2` or `4.0.1`)                  |
 
 The same variables are available in these templates as were available in the pull request description templates.
 
@@ -98,7 +99,7 @@ The configuration file has the following properties:
 
 **`labelTypeMap`** and `labelType
 
-These will map label types to a heading for grouping the changelog. For instance if you prefix your issue types with `type:` (eg. `type: bug`), then you would give the `labelTypePrefix` a value of `type: ` and implement `bug` as a property in the `labelTypeMap`.
+These will map label types to a heading for grouping the changelog. For instance if you prefix your issue types with `type:` (eg. `type: bug`), then you would give the `labelTypePrefix` a value of `type:` and implement `bug` as a property in the `labelTypeMap`.
 
 **`groupTitleOrder`**
 
@@ -118,12 +119,16 @@ This is a label your project uses to indicate pull requests that require some ad
 
 You can add any labels here that the changelog generator should use as a signal to omit the pull request from being included in the generated changelog.
 
+**`releasePRLabels`**
+
+You can add any labels here which will be attached to the new PR automatically created for each release. It defaults to adding `type: release` and `skip-changelog`.
+
 ## API
 
 ### Inputs
 
-- `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
-- `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
+-   `github_token`: Required. GitHub API token to use for making API requests. You can use the default `secrets.GITHUB_TOKEN` used by GitHub actions or store a different one in the secrets configuration of your GitHub repository.
+-   `automations`: Optional. You can include a comma-delimited list of specific automations you want to run if you don't want to use them all in a given workflow.
 
 ### Outputs
 

--- a/lib/automations/release/branch-create-handler.js
+++ b/lib/automations/release/branch-create-handler.js
@@ -41,9 +41,11 @@ const insertNewChangelogEntry = ( contents, changelog, releaseVersion ) => {
 	const regex = /== Changelog ==\n/;
 	return contents.replace(
 		regex,
-		`== Changelog ==\n\n= ${ releaseVersion } - ${ new Date().toISOString().split('T')[0] } =\n\n${ changelog }`
+		`== Changelog ==\n\n= ${ releaseVersion } - ${
+			new Date().toISOString().split( 'T' )[ 0 ]
+		} =\n\n${ changelog }`
 	);
-}
+};
 
 /**
  * Inserts the new changelog entry into the readme file contents
@@ -322,6 +324,12 @@ const branchHandler = async ( context, octokit, config ) => {
 	const commentBody = lineBreak(
 		compile( initialChecklistTemplate )( templateData )
 	);
+
+	await octokit.issues.addLabels( {
+		...context.repo,
+		issue_number: prCreated.data.number,
+		labels: config.releasePRLabels,
+	} );
 
 	await octokit.issues.createComment( {
 		...context.repo,

--- a/lib/automations/release/config/default.json
+++ b/lib/automations/release/config/default.json
@@ -30,5 +30,9 @@
 	"needsDevNoteLabel": "status:needs-dev-note",
 	"labelsToOmit": [
 		"skip-changelog"
+	],
+	"releasePRLabels": [
+		"skip-changelog",
+		"type: release"
 	]
 }

--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -81,6 +81,7 @@
  * @property {Array<string>}          labelsToOmit      When any label in this array is attached to
  *                                                      an issue/pull, then the entry should be
  *                                                      ignored in the changelog.
+ * @property {Array<string>}          releasePRLabels   Labels to add to the release PR.
  */
 
 module.exports = {};


### PR DESCRIPTION
This PR adds the ability to configure labels which will be automatically added to the release PR. By default, this will add `type: release` and `skip-changelog`. The rationale behind this is that in some occasions the release PR leaked into the changelog of the next release, requiring the release lead to manually remove it.

Fixes [woocommerce-blocks/#7742](https://github.com/woocommerce/woocommerce-blocks/issues/7742).

I was on the fence on whether `type: release` should be added by default as repos using this package might not necessarily have that label, and we could configure that to be added in our repo. On the other hand, `skip-changelog` is pretty much required by this package, so I thought it's entirely ok to have it as default.

All in all, I think it is sensible to leave `type: release` as well, but happy to change my mind.

### Testing instructions

To test this, you will need to:

- **Fork** the `woocommerce-gutenberg-products-block` and then unfork it (Go to this url: https://support.github.com/contact?tags=rr-forks and type `unfork` into the subject line. Follow the steps from the virtual assistant and wait 5-10 mins for the request to be actioned).
- Enable issues on your new unforked repository (go to `Settings > General > Features > Issues`).
- Activate GH actions.
- Give read and write permissions to the workflows: Settings > Actions > General > Workflow permissions
- Allow GH actions to create PRs: Settings > Actions > General.
- Create a milestone.
- Clone your repository locally.
- Create a PR on your repository, in this PR you should change the following file: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/.github/workflows/release-pull-request.yml#L27 .
- Change the highlighted line to read: `uses: woocommerce/automations@add/release-pr-labels`.
- Merge the PR.
- Optionally create multiple PRs.
- Assign them all to the milestone you created earlier.
- Create a new branch, prefixed with `release/` and whatever milestone number you picked.
- Push this branch to the remote.
- Go to your repository on GitHub, you should see a new PR created for the release, and it should have added the default labels to the PR.

#### Additional testing
- [ ] Add a `releasePRLabels` to your repository `release-automation-config.json` with your custom labels, and check that those are added correctly.