### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - run: npm run test
     # if tests pass then build.
     - run: npm run build
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
       with:
         commit_message: Update built file.
         commit_options: '--no-verify --signoff'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     - run: npm ci
-    - uses: mattallty/jest-github-action@v1
+    - uses: mattallty/jest-github-action@40eafe1b6e3924992dd7e3b0a07e70dfdff1d52f # v1
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes [QAO-38](https://linear.app/a8c/issue/QAO-38/pin-github-actions-to-full-commit-shas)

Pins Github actions to full commit SHAs as immutable references.
Skipped all official GitHub actions.  
No version updates - used the latest commit in the tag that was already used.